### PR TITLE
🔀 :: FirstSprint  Self-confirmation and authentication View

### DIFF
--- a/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/SelfConfirmScreen.kt
+++ b/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/SelfConfirmScreen.kt
@@ -1,0 +1,149 @@
+package com.example.dms_android.feature.auth.selfconfirmation
+
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.design_system.button.DormButtonColor
+import com.example.design_system.button.DormContainedLargeButton
+import com.example.design_system.color.DormColor
+import com.example.design_system.icon.DormIcon
+import com.example.design_system.textfield.DormTextField
+import com.example.design_system.typography.Body4
+import com.example.design_system.typography.Body5
+import com.example.dms_android.R
+
+@Preview
+@Composable
+fun SelfConfirmScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DormColor.Gray100)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(top = 77.dp)
+        ) {
+            Image(
+                painter = painterResource(id = DormIcon.Applicate.drawableId),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(49.dp),
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(7.dp)
+            )
+            Body4(
+                text = stringResource(R.string.VerificationMine),
+                color = DormColor.Gray600,
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(60.dp)
+            )
+            IdTextField()
+            CorrectIdView()
+            Box(
+                contentAlignment = Alignment.BottomCenter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 60.dp),
+            ) {
+                DormContainedLargeButton(
+                    text = stringResource(R.string.Next),
+                    color = DormButtonColor.Blue,
+                    enabled = false,
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun IdTextField() {
+    var idValue by remember { mutableStateOf(String()) }
+    DormTextField(
+        value = idValue,
+        onValueChange = { idValue = it },
+        error = stringResource(
+            R.string.NotSameName
+        ),
+        hint = stringResource(R.string.enter_id),
+    )
+}
+
+@Composable
+fun CorrectIdView() {
+    Spacer(
+        modifier = Modifier
+            .height(12.dp)
+    )
+    Column(
+        modifier = Modifier
+            .height(68.dp)
+            .fillMaxWidth()
+            .background(color = DormColor.Gray200),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(10.dp))
+            Body5(text = stringResource(R.string.SameIdAndEmail))
+            Spacer(modifier = Modifier.height(5.dp))
+            //TODO:Id들어갈 자리입니다
+            Body5(text = "id", color = DormColor.Darken200)
+        }
+
+    }
+
+    Spacer(
+        modifier = Modifier
+            .height(24.dp)
+    )
+    var nameValue by remember { mutableStateOf(String()) }
+    DormTextField(
+        value = nameValue,
+        onValueChange = { nameValue = it },
+        hint = stringResource(R.string.EnterName),
+    )
+    Spacer(
+        modifier = Modifier
+            .height(37.dp)
+    )
+    var emailValue by remember { mutableStateOf(String()) }
+    DormTextField(
+        value = emailValue,
+        onValueChange = { emailValue = it },
+        hint = stringResource(R.string.enter_email_address),
+    )
+}
+
+@Composable
+fun VerificationOtpView() {
+
+}

--- a/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/SelfConfirmScreen.kt
+++ b/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/SelfConfirmScreen.kt
@@ -43,8 +43,18 @@ fun SelfConfirmScreen() {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp)
-                .padding(top = 77.dp)
+                .padding(top = 16.dp)
         ) {
+            Image(
+                modifier = Modifier
+                    .size(24.dp),
+                painter = painterResource(id = DormIcon.BackArrow.drawableId),
+                contentDescription = stringResource(id = R.string.backButton),
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(37.dp)
+            )
             Image(
                 painter = painterResource(id = DormIcon.Applicate.drawableId),
                 contentDescription = null,

--- a/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/VeritificationScreen.kt
+++ b/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/VeritificationScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.design_system.button.DormButtonColor
 import com.example.design_system.button.DormContainedLargeButton
@@ -33,6 +34,7 @@ import com.example.dms_android.R
 import com.example.dms_android.feature.register.screen.component.OTP_VIEW_TYPE_UNDERLINE
 import com.example.dms_android.feature.register.screen.component.OtpView
 
+@Preview
 @Composable
 fun VerificationScreen() {
 
@@ -46,8 +48,18 @@ fun VerificationScreen() {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp)
-                .padding(top = 77.dp)
+                .padding(top = 16.dp)
         ) {
+            Image(
+                modifier = Modifier
+                    .size(24.dp),
+                painter = painterResource(id = DormIcon.BackArrow.drawableId),
+                contentDescription = stringResource(id = R.string.backButton),
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(37.dp)
+            )
             Image(
                 painter = painterResource(id = DormIcon.Applicate.drawableId),
                 contentDescription = null,

--- a/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/VeritificationScreen.kt
+++ b/presentation/src/main/java/com/example/dms_android/feature/auth/selfconfirmation/VeritificationScreen.kt
@@ -1,0 +1,133 @@
+package com.example.dms_android.feature.auth.selfconfirmation
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.example.design_system.button.DormButtonColor
+import com.example.design_system.button.DormContainedLargeButton
+import com.example.design_system.color.DormColor
+import com.example.design_system.icon.DormIcon
+import com.example.design_system.typography.Body4
+import com.example.design_system.typography.Body5
+import com.example.design_system.typography.ButtonText
+import com.example.dms_android.R
+import com.example.dms_android.feature.register.screen.component.OTP_VIEW_TYPE_UNDERLINE
+import com.example.dms_android.feature.register.screen.component.OtpView
+
+@Composable
+fun VerificationScreen() {
+
+    var otpValue by remember { mutableStateOf("") }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DormColor.Gray200)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(top = 77.dp)
+        ) {
+            Image(
+                painter = painterResource(id = DormIcon.Applicate.drawableId),
+                contentDescription = null,
+                modifier = Modifier.size(49.dp),
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(7.dp)
+            )
+            Body4(
+                text = stringResource(R.string.VerificationMine),
+                color = DormColor.Gray600,
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(100.dp)
+            )
+            OtpView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 30.dp),
+                otpText = otpValue,
+                onOtpTextChange = {
+                    otpValue = it
+                },
+                otpCount = 6,
+                type = OTP_VIEW_TYPE_UNDERLINE,
+                password = true,
+                containerSize = 24.dp,
+                passwordChar = "⚫",
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                charColor = DormColor.Gray600,
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(40.dp)
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Body5(
+                    text = stringResource(R.string.EmailSixCode),
+                    color = DormColor.Gray500,
+                )
+                Spacer(
+                    modifier = Modifier
+                        .height(8.dp)
+                )
+                Body5(
+                    text = "3 : 00",
+                    color = DormColor.DormPrimary,
+                )
+            }
+
+            Box(
+                contentAlignment = Alignment.BottomCenter,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 60.dp),
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    ButtonText(
+                        text = stringResource(R.string.ResendVerificationCode),
+                        color = DormColor.Gray600
+                    )
+                    Spacer(
+                        modifier = Modifier
+                            .height(29.dp)
+                    )
+                    DormContainedLargeButton(
+                        text = stringResource(R.string.verification),
+                        color = DormButtonColor.Blue,
+                        enabled = false,
+                    ) {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -10,13 +10,16 @@
     <string name="enter_id">아이디 입력</string>
     <string name="using_id">사용중인 아이디입니다.</string>
     <string name="next">다음</string>
+    <string name="NotSameName">일치하는 아이디가 존재하지 않습니다.</string>
     <string name="question_confirm_school">학교 확인 질문</string>
     <string name="school_students">우리 학교 학생 수는?</string>
     <string name="inconsistent_school_reply">학교 인증 질문과 답변이 일치하지 않습니다!</string>
     <string name="reply">답변</string>
     <string name="verification">인증</string>
+    <string name="VerificationMine">계정 본인인증</string>
     <string name="already_account">이미 계정이 있으신가요?</string>
     <string name="login">로그인</string>
+    <string name="EnterName">이름 입력</string>
     <string name="set_password">비밀번호 설정</string>
     <string name="enter_password">비밀번호 입력</string>
     <string name="reenter_password">비밀번호 재입력</string>
@@ -41,6 +44,7 @@
     <string name="ChangePasswordUnAuthorized">이메일 인증번호가 틀립니다.</string>
     <string name="ChangePasswordNotFound">해당 사용자를 찾을 수 없습니다.</string>
     <string name="ScanNewPassword">새 비밀번호 입력</string>
+    <string name="SameIdAndEmail">아이디와 일치하는 이메일입니다.</string>
     <string name="CheckScanNewPassword">새 비밀번호 재 확인</string>
     <string name="ProfileImage">프로필 사진</string>
     <string name="SettingLater">다음에 설정하기</string>


### PR DESCRIPTION
## 개요
> 본인확인 인증 뷰를 구현합니다.

## 작업사항
-  본인확인 인증뷰를 크게 두 화면으로 나누어서 작업하였습니다.(아래)
- OTP, TextField있는 화면

### View
![image](https://user-images.githubusercontent.com/90879448/197381125-2c36eac7-3f74-494a-9a55-7cee48a7d451.png)
![image](https://user-images.githubusercontent.com/90879448/197381137-24d5daa2-b4c4-4ae9-8e3c-a8fa24c5eb07.png)


## 추가 로 할 말
시