### PR TITLE
🔀 :: 학번 검사 비즈니스 로직 구현

### DIFF
--- a/auth_data/src/main/java/com/example/auth_data/remote/api/StudentsApi.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/api/StudentsApi.kt
@@ -2,6 +2,7 @@ package com.example.auth_data.remote.api
 
 import com.example.auth_data.remote.request.students.ResetPasswordRequest
 import com.example.auth_data.remote.request.students.SignUpRequest
+import com.example.auth_data.remote.response.students.ExamineGradeResponse
 import com.example.auth_data.remote.response.students.SignUpResponse
 import com.example.auth_data.remote.url.DmsUrl
 import retrofit2.http.Body
@@ -9,12 +10,13 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Query
+import java.util.UUID
 
 interface StudentsApi {
     @POST(DmsUrl.Students.register)
     suspend fun postRegister(
         signUpRequest: SignUpRequest,
-    ) : SignUpResponse
+    ): SignUpResponse
 
     @GET(DmsUrl.Students.duplicateCheckId)
     suspend fun duplicateCheckId(
@@ -30,4 +32,12 @@ interface StudentsApi {
     suspend fun resetPassword(
         @Body resetPasswordRequest: ResetPasswordRequest
     )
+
+    @GET(DmsUrl.Students.examineGrade)
+    suspend fun examineGrade(
+        @Query("school_id") schoolId: UUID,
+        @Query("grade") grade: Int,
+        @Query("class_room") classRoom: Int,
+        @Query("number") number: Int,
+    ): ExamineGradeResponse
 }

--- a/auth_data/src/main/java/com/example/auth_data/remote/datasource/declaration/RemoteStudentsDataSource.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/datasource/declaration/RemoteStudentsDataSource.kt
@@ -2,7 +2,9 @@ package com.example.auth_data.remote.datasource.declaration
 
 import com.example.auth_data.remote.request.students.ResetPasswordRequest
 import com.example.auth_data.remote.request.students.SignUpRequest
+import com.example.auth_data.remote.response.students.ExamineGradeResponse
 import com.example.auth_data.remote.response.students.SignUpResponse
+import java.util.UUID
 
 interface RemoteStudentsDataSource {
     suspend fun postUserSignUp(
@@ -20,4 +22,11 @@ interface RemoteStudentsDataSource {
     suspend fun resetPassword(
         resetPasswordRequest: ResetPasswordRequest
     )
+
+    suspend fun examineGrade(
+        schoolId: UUID,
+        grade: Int,
+        classRoom: Int,
+        number: Int,
+    ): ExamineGradeResponse
 }

--- a/auth_data/src/main/java/com/example/auth_data/remote/datasource/implementation/RemoteStudentsDataSourceImpl.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/datasource/implementation/RemoteStudentsDataSourceImpl.kt
@@ -57,10 +57,10 @@ class RemoteStudentsDataSourceImpl @Inject constructor(
     ) = HttpHandler<ExamineGradeResponse>()
         .httpRequest {
             studentsApi.examineGrade(
-                schoolId,
-                grade,
-                classRoom,
-                number,
+                schoolId = schoolId,
+                grade = grade,
+                classRoom = classRoom,
+                number = number,
             )
         }.sendRequest()
 }

--- a/auth_data/src/main/java/com/example/auth_data/remote/datasource/implementation/RemoteStudentsDataSourceImpl.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/datasource/implementation/RemoteStudentsDataSourceImpl.kt
@@ -4,8 +4,10 @@ import com.example.auth_data.remote.api.StudentsApi
 import com.example.auth_data.remote.datasource.declaration.RemoteStudentsDataSource
 import com.example.auth_data.remote.request.students.ResetPasswordRequest
 import com.example.auth_data.remote.request.students.SignUpRequest
+import com.example.auth_data.remote.response.students.ExamineGradeResponse
 import com.example.auth_data.remote.response.students.SignUpResponse
 import com.example.auth_data.util.HttpHandler
+import java.util.UUID
 import javax.inject.Inject
 
 class RemoteStudentsDataSourceImpl @Inject constructor(
@@ -45,6 +47,20 @@ class RemoteStudentsDataSourceImpl @Inject constructor(
             studentsApi.resetPassword(
                 resetPasswordRequest
             )
-        }
-        .sendRequest()
+        }.sendRequest()
+
+    override suspend fun examineGrade(
+        schoolId: UUID,
+        grade: Int,
+        classRoom: Int,
+        number: Int
+    ) = HttpHandler<ExamineGradeResponse>()
+        .httpRequest {
+            studentsApi.examineGrade(
+                schoolId,
+                grade,
+                classRoom,
+                number,
+            )
+        }.sendRequest()
 }

--- a/auth_data/src/main/java/com/example/auth_data/remote/response/students/ExamineGradeResponse.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/response/students/ExamineGradeResponse.kt
@@ -1,0 +1,7 @@
+package com.example.auth_data.remote.response.students
+
+import com.google.gson.annotations.SerializedName
+
+data class ExamineGradeResponse(
+    @SerializedName("name") val name: String
+)

--- a/auth_data/src/main/java/com/example/auth_data/remote/url/DmsUrl.kt
+++ b/auth_data/src/main/java/com/example/auth_data/remote/url/DmsUrl.kt
@@ -19,6 +19,7 @@ object DmsUrl {
         const val duplicateCheckId = "$students/account-id/duplication"
         const val duplicateCheckEmail = "$students/email/duplication"
         const val resetPassword = "$students/password/initialization"
+        const val examineGrade = "$students/name"
     }
 
     object Schools {

--- a/auth_data/src/main/java/com/example/auth_data/repository/StudentsRepositoryImpl.kt
+++ b/auth_data/src/main/java/com/example/auth_data/repository/StudentsRepositoryImpl.kt
@@ -3,7 +3,10 @@ package com.example.auth_data.repository
 import com.example.auth_data.remote.datasource.declaration.RemoteStudentsDataSource
 import com.example.auth_data.remote.request.students.ResetPasswordRequest
 import com.example.auth_data.remote.request.students.SignUpRequest
+import com.example.auth_data.remote.response.students.ExamineGradeResponse
 import com.example.auth_data.remote.response.students.SignUpResponse
+import com.example.auth_domain.entity.ExamineGradeEntity
+import com.example.auth_domain.param.ExamineGradeParam
 import com.example.auth_domain.param.RegisterParam
 import com.example.auth_domain.param.ResetPasswordParam
 import com.example.auth_domain.repository.StudentsRepository
@@ -16,30 +19,32 @@ class StudentsRepositoryImpl @Inject constructor(
     private val localUserDataSource: LocalUserDataSource,
 ) : StudentsRepository {
 
-    override suspend fun register(
-        registerParam: RegisterParam,
-    ) {
+    override suspend fun register(registerParam: RegisterParam) {
         val response = remoteStudentsDataSource.postUserSignUp(
             registerParam.toRequest()
         )
         localUserDataSource.setUserVisibleInform(response.features.toEntity())
     }
 
-    override suspend fun duplicateCheckId(
-        accountId: String,
-    ) = remoteStudentsDataSource.duplicateCheckId(accountId)
+    override suspend fun duplicateCheckId(accountId: String) =
+        remoteStudentsDataSource.duplicateCheckId(accountId)
 
-    override suspend fun duplicateCheckEmail(
-        email: String,
-    ) = remoteStudentsDataSource.duplicateCheckEmail(email)
+    override suspend fun duplicateCheckEmail(email: String) =
+        remoteStudentsDataSource.duplicateCheckEmail(email)
 
-    override suspend fun resetPassword(
-        resetPasswordParam: ResetPasswordParam
-    ) {
+    override suspend fun resetPassword(resetPasswordParam: ResetPasswordParam) {
         remoteStudentsDataSource.resetPassword(
             resetPasswordParam.toRequest()
         )
     }
+
+    override suspend fun examineGrade(examineGradeParam: ExamineGradeParam): ExamineGradeEntity =
+        remoteStudentsDataSource.examineGrade(
+            schoolId = examineGradeParam.schoolId,
+            grade = examineGradeParam.grade,
+            number = examineGradeParam.number,
+            classRoom = examineGradeParam.classRoom,
+        ).toEntity()
 
     private fun SignUpResponse.Features.toEntity() =
         FeaturesParam(
@@ -68,5 +73,10 @@ class StudentsRepositoryImpl @Inject constructor(
             accountId = accountId,
             password = password,
             profileImageUrl = profileImageUrl,
+        )
+
+    private fun ExamineGradeResponse.toEntity() =
+        ExamineGradeEntity(
+            name = name
         )
 }

--- a/auth_domain/src/main/java/com/example/auth_domain/entity/ExamineGradeEntity.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/entity/ExamineGradeEntity.kt
@@ -1,0 +1,5 @@
+package com.example.auth_domain.entity
+
+data class ExamineGradeEntity(
+    val name: String
+)

--- a/auth_domain/src/main/java/com/example/auth_domain/param/ExamineGradeParam.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/param/ExamineGradeParam.kt
@@ -1,0 +1,10 @@
+package com.example.auth_domain.param
+
+import java.util.UUID
+
+data class ExamineGradeParam(
+    val schoolId: UUID,
+    val grade: Int,
+    val classRoom: Int,
+    val number: Int,
+)

--- a/auth_domain/src/main/java/com/example/auth_domain/repository/StudentsRepository.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/repository/StudentsRepository.kt
@@ -1,12 +1,14 @@
 package com.example.auth_domain.repository
 
+import com.example.auth_domain.entity.ExamineGradeEntity
+import com.example.auth_domain.param.ExamineGradeParam
 import com.example.auth_domain.param.RegisterParam
 import com.example.auth_domain.param.ResetPasswordParam
 
 interface StudentsRepository {
 
     suspend fun register(
-        registerParam: RegisterParam,
+        registerParam: RegisterParam
     )
 
     suspend fun duplicateCheckId(
@@ -20,4 +22,8 @@ interface StudentsRepository {
     suspend fun resetPassword(
         resetPasswordParam: ResetPasswordParam
     )
+
+    suspend fun examineGrade(
+        examineGradeParam: ExamineGradeParam
+    ): ExamineGradeEntity
 }

--- a/auth_domain/src/main/java/com/example/auth_domain/usecase/students/DuplicateCheckEmailUseCase.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/usecase/students/DuplicateCheckEmailUseCase.kt
@@ -4,10 +4,10 @@ import com.example.auth_domain.repository.StudentsRepository
 import com.example.auth_domain.usecase.UseCase
 import javax.inject.Inject
 
-class duplicateCheckIdUseCase @Inject constructor(
+class DuplicateCheckEmailUseCase @Inject constructor(
     private val studentsRepository: StudentsRepository
 ) : UseCase<String, Unit>() {
     override suspend fun execute(data: String) {
-        studentsRepository.duplicateCheckId(data)
+        studentsRepository.duplicateCheckEmail(data)
     }
 }

--- a/auth_domain/src/main/java/com/example/auth_domain/usecase/students/DuplicateCheckIdUseCase.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/usecase/students/DuplicateCheckIdUseCase.kt
@@ -4,10 +4,10 @@ import com.example.auth_domain.repository.StudentsRepository
 import com.example.auth_domain.usecase.UseCase
 import javax.inject.Inject
 
-class duplicateCheckEmailUseCase @Inject constructor(
+class DuplicateCheckIdUseCase @Inject constructor(
     private val studentsRepository: StudentsRepository
 ) : UseCase<String, Unit>() {
     override suspend fun execute(data: String) {
-        studentsRepository.duplicateCheckEmail(data)
+        studentsRepository.duplicateCheckId(data)
     }
 }

--- a/auth_domain/src/main/java/com/example/auth_domain/usecase/students/ExamineGradeUseCase.kt
+++ b/auth_domain/src/main/java/com/example/auth_domain/usecase/students/ExamineGradeUseCase.kt
@@ -1,0 +1,14 @@
+package com.example.auth_domain.usecase.students
+
+import com.example.auth_domain.entity.ExamineGradeEntity
+import com.example.auth_domain.param.ExamineGradeParam
+import com.example.auth_domain.repository.StudentsRepository
+import com.example.auth_domain.usecase.UseCase
+import javax.inject.Inject
+
+class ExamineGradeUseCase @Inject constructor(
+    private val studentsRepository: StudentsRepository
+): UseCase<ExamineGradeParam, ExamineGradeEntity>(){
+    override suspend fun execute(data: ExamineGradeParam): ExamineGradeEntity =
+        studentsRepository.examineGrade(data)
+}


### PR DESCRIPTION
## 개요
> 학번검사 비즈니스로직 구현

## 작업사항
- 학번검사 비즈니스 로직 작성
- 기존 코드 조금의 리팩토링
- 이메일체크 ,아이디 체크 UseCase의 네이밍을 수정하였습니다.

## 추가 로 할 말
api 명세에 추가되어 작성했습니다.
