### PR TITLE
🔀 :: (#190) Add @AndroidEntrypoint annotations on fragments related to Register

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EmailCertificationFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EmailCertificationFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.event.email.RegisterEmailEvent
@@ -16,6 +17,7 @@ import team.aliens.dms_android.viewmodel.auth.register.email.RegisterEmailViewMo
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentEmailCertificationBinding
 
+@AndroidEntryPoint
 class EmailCertificationFragment :
     BaseFragment<FragmentEmailCertificationBinding>(R.layout.fragment_email_certification) {
     private val registerEmailViewModel: RegisterEmailViewModel by viewModels()

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EnterEmailFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EnterEmailFragment.kt
@@ -6,6 +6,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.util.emailValidation
@@ -14,6 +15,7 @@ import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentEnterEmailBinding
 import java.util.regex.Pattern
 
+@AndroidEntryPoint
 class EnterEmailFragment : BaseFragment<FragmentEnterEmailBinding>(R.layout.fragment_enter_email) {
     private var emailAddress: String = ""
     private var inputData = ""

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/id/SetIdFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/id/SetIdFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.event.id.SetIdEvent
@@ -19,6 +20,7 @@ import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentSetIdBinding
 import java.util.*
 
+@AndroidEntryPoint
 class SetIdFragment : BaseFragment<FragmentSetIdBinding>(R.layout.fragment_set_id) {
     private val setIdViewModel: SetIdViewModel by viewModels()
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/last/PolicyFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/last/PolicyFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.MainActivity
 import team.aliens.dms_android.feature.RegisterActivity
@@ -18,6 +19,7 @@ import team.aliens.domain.param.RegisterParam
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentPolicyBinding
 
+@AndroidEntryPoint
 class PolicyFragment : BaseFragment<FragmentPolicyBinding>(R.layout.fragment_policy) {
     private val signUpViewModel: SignUpViewModel by viewModels()
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/last/SetProfileImageFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/last/SetProfileImageFragment.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentSetProfileImageBinding
 
+@AndroidEntryPoint
 class SetProfileImageFragment :
     BaseFragment<FragmentSetProfileImageBinding>(R.layout.fragment_set_profile_image) {
     private var pwd = ""

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
@@ -6,6 +6,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.ui.last.SetProfileImageFragment
@@ -13,6 +14,7 @@ import team.aliens.dms_android.util.visible
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentSetPasswordBinding
 
+@AndroidEntryPoint
 class SetPasswordFragment :
     BaseFragment<FragmentSetPasswordBinding>(R.layout.fragment_set_password) {
     private var pwd = ""

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.MainActivity
 import team.aliens.dms_android.feature.RegisterActivity
@@ -23,6 +24,7 @@ import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentConfirmSchoolBinding
 import java.util.*
 
+@AndroidEntryPoint
 class ConfirmSchoolFragment :
     BaseFragment<FragmentConfirmSchoolBinding>(R.layout.fragment_confirm_school) {
     private val confirmSchoolViewModel: ConfirmSchoolViewModel by viewModels()

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/SchoolCertificationFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/SchoolCertificationFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.event.school.ExamineSchoolCodeEvent
@@ -14,6 +15,7 @@ import team.aliens.dms_android.viewmodel.auth.register.school.ExamineSchoolCodeV
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentSchoolCertificationBinding
 
+@AndroidEntryPoint
 class SchoolCertificationFragment :
     BaseFragment<FragmentSchoolCertificationBinding>(R.layout.fragment_school_certification) {
     private val examineSchoolCodeViewModel: ExamineSchoolCodeViewModel by viewModels()


### PR DESCRIPTION
## 개요
> 이전 프로젝트 패키지 이름 변경 작업에서, Register 로직과 관련된 각 프래그먼트에 명시되어 있던 `@AndroidEntryPoint` 애너테이션이 누락되었고, 해당 프래그먼트에 접근하는 경우 앱이 종료되는 현상을 해결합니다.

## 작업사항
- Register 로직과 관련된 각 프래그먼트에 `@AndroidEntryPoint` 애너테이션을 명시하였습니다
  ![image](https://user-images.githubusercontent.com/101160207/218252525-051fabbe-b8d5-4095-9d33-97f237972276.png)


## 추가 로 할 말
- .