### PR TITLE
🔀 :: (#201) implement remain entities and repositories in domain and data layer

### DIFF
--- a/data/src/main/java/team/aliens/data/remote/api/RemainApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/RemainApi.kt
@@ -1,0 +1,27 @@
+package team.aliens.data.remote.api
+
+import retrofit2.http.GET
+import retrofit2.http.PUT
+import retrofit2.http.Query
+import team.aliens.data.remote.response.remain.FetchAvailableRemainTimeResponse
+import team.aliens.data.remote.response.remain.FetchCurrentRemainOptionResponse
+import team.aliens.data.remote.response.remain.FetchRemainOptionsResponse
+import team.aliens.data.remote.url.DmsUrl
+import java.util.*
+
+interface RemainApi {
+
+    @PUT(DmsUrl.Remain.updateRemainOption)
+    fun updateRemainOption(
+        @Query("remain-option-id") remainOptionId: UUID,
+    )
+
+    @GET(DmsUrl.Remain.fetchCurrentRemainOption)
+    fun fetchCurrentRemainOption(): FetchCurrentRemainOptionResponse
+
+    @GET(DmsUrl.Remain.fetchAvailableRemainTime)
+    fun fetchAvailableRemainTime(): FetchAvailableRemainTimeResponse
+
+    @GET(DmsUrl.Remain.fetchRemainOptions)
+    fun fetchRemainOptions(): FetchRemainOptionsResponse
+}

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteRemainDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteRemainDataSource.kt
@@ -1,0 +1,19 @@
+package team.aliens.data.remote.datasource.declaration
+
+import team.aliens.data.remote.response.remain.FetchAvailableRemainTimeResponse
+import team.aliens.data.remote.response.remain.FetchCurrentRemainOptionResponse
+import team.aliens.data.remote.response.remain.FetchRemainOptionsResponse
+import java.util.*
+
+interface RemoteRemainDataSource {
+
+    suspend fun updateRemainOption(
+        remainOptionId: UUID,
+    )
+
+    suspend fun fetchCurrentRemainOption(): FetchCurrentRemainOptionResponse
+
+    suspend fun fetchAvailableRemainTime(): FetchAvailableRemainTimeResponse
+
+    suspend fun fetchRemainOptions(): FetchRemainOptionsResponse
+}

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteRemainDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteRemainDataSourceImpl.kt
@@ -1,0 +1,49 @@
+package team.aliens.data.remote.datasource.implementation
+
+import team.aliens.data.remote.api.RemainApi
+import team.aliens.data.remote.datasource.declaration.RemoteRemainDataSource
+import team.aliens.data.remote.response.remain.FetchAvailableRemainTimeResponse
+import team.aliens.data.remote.response.remain.FetchCurrentRemainOptionResponse
+import team.aliens.data.remote.response.remain.FetchRemainOptionsResponse
+import team.aliens.data.util.sendHttpRequest
+import java.util.*
+import javax.inject.Inject
+
+class RemoteRemainDataSourceImpl @Inject constructor(
+    private val remainApi: RemainApi,
+) : RemoteRemainDataSource {
+
+    override suspend fun updateRemainOption(remainOptionId: UUID) {
+        sendHttpRequest(
+            httpRequest = {
+                remainApi.updateRemainOption(
+                    remainOptionId = remainOptionId,
+                )
+            },
+        )
+    }
+
+    override suspend fun fetchCurrentRemainOption(): FetchCurrentRemainOptionResponse {
+        return sendHttpRequest(
+            httpRequest = {
+                remainApi.fetchCurrentRemainOption()
+            },
+        )
+    }
+
+    override suspend fun fetchAvailableRemainTime(): FetchAvailableRemainTimeResponse {
+        return sendHttpRequest(
+            httpRequest = {
+                remainApi.fetchAvailableRemainTime()
+            },
+        )
+    }
+
+    override suspend fun fetchRemainOptions(): FetchRemainOptionsResponse {
+        return sendHttpRequest(
+            httpRequest = {
+                remainApi.fetchRemainOptions()
+            },
+        )
+    }
+}

--- a/data/src/main/java/team/aliens/data/remote/response/remain/FetchAvailableRemainTimeResponse.kt
+++ b/data/src/main/java/team/aliens/data/remote/response/remain/FetchAvailableRemainTimeResponse.kt
@@ -1,0 +1,21 @@
+package team.aliens.data.remote.response.remain
+
+import com.google.gson.annotations.SerializedName
+import team.aliens.domain.entity.remain.AvailableRemainTimeEntity
+import java.time.DayOfWeek
+
+data class FetchAvailableRemainTimeResponse(
+    @SerializedName("start_day_of_week") val startDayOfWeek: DayOfWeek,
+    @SerializedName("start_at") val startsAt: String,
+    @SerializedName("end_day_of_week") val endDayOfWeek: DayOfWeek,
+    @SerializedName("end_at") val endsAt: String,
+)
+
+fun FetchAvailableRemainTimeResponse.toEntity(): AvailableRemainTimeEntity {
+    return AvailableRemainTimeEntity(
+        startDayOfWeek = this.startDayOfWeek,
+        startsAt = this.startsAt,
+        endDayOfWeek = this.endDayOfWeek,
+        endsAt = this.endsAt,
+    )
+}

--- a/data/src/main/java/team/aliens/data/remote/response/remain/FetchCurrentRemainOptionResponse.kt
+++ b/data/src/main/java/team/aliens/data/remote/response/remain/FetchCurrentRemainOptionResponse.kt
@@ -1,0 +1,14 @@
+package team.aliens.data.remote.response.remain
+
+import com.google.gson.annotations.SerializedName
+import team.aliens.domain.entity.remain.CurrentRemainOptionEntity
+
+data class FetchCurrentRemainOptionResponse(
+    @SerializedName("title") val title: String,
+)
+
+fun FetchCurrentRemainOptionResponse.toEntity(): CurrentRemainOptionEntity {
+    return CurrentRemainOptionEntity(
+        title = this.title,
+    )
+}

--- a/data/src/main/java/team/aliens/data/remote/response/remain/FetchRemainOptionsResponse.kt
+++ b/data/src/main/java/team/aliens/data/remote/response/remain/FetchRemainOptionsResponse.kt
@@ -1,0 +1,35 @@
+package team.aliens.data.remote.response.remain
+
+import com.google.gson.annotations.SerializedName
+import team.aliens.data.remote.response.remain.FetchRemainOptionsResponse.RemainOptionResponse
+import team.aliens.domain.entity.remain.RemainOptionsEntity
+import team.aliens.domain.entity.remain.RemainOptionsEntity.RemainOptionEntity
+import java.util.*
+
+data class FetchRemainOptionsResponse(
+    @SerializedName("selected_option") val selectedOption: String,
+    @SerializedName("remain_options") val remainOptionEntities: List<RemainOptionResponse>,
+) {
+    data class RemainOptionResponse(
+        @SerializedName("id") val id: UUID,
+        @SerializedName("title") val title: String,
+        @SerializedName("description") val description: String,
+    )
+}
+
+fun RemainOptionResponse.toEntity(): RemainOptionEntity {
+    return RemainOptionEntity(
+        id = this.id,
+        title = this.title,
+        description = this.description,
+    )
+}
+
+fun FetchRemainOptionsResponse.toEntity(): RemainOptionsEntity {
+    return RemainOptionsEntity(
+        selectedOption = this.selectedOption,
+        remainOptionEntities = this.remainOptionEntities.map {
+            it.toEntity()
+        },
+    )
+}

--- a/data/src/main/java/team/aliens/data/remote/url/DmsUrl.kt
+++ b/data/src/main/java/team/aliens/data/remote/url/DmsUrl.kt
@@ -8,6 +8,7 @@ object DmsUrl {
     const val auth = "/auth"
     const val schools = "/schools"
     const val studyRoom = "/study-rooms"
+    const val remains = "/remains"
 
     object User {
         const val login = "$auth/tokens"
@@ -48,5 +49,12 @@ object DmsUrl {
         const val StudyRoomList = "$studyRoom/list/students"
         const val StudyRoomType = "$studyRoom/types"
         const val StudyRoomDetail = "$studyRoom/{study-room-id}/students"
+    }
+
+    object Remain {
+        const val updateRemainOption = "$remains/{remain-option-id}"
+        const val fetchCurrentRemainOption = "$remains/my"
+        const val fetchAvailableRemainTime = "$remains/available-time"
+        const val fetchRemainOptions = "$remains/options"
     }
 }

--- a/data/src/main/java/team/aliens/data/repository/RemainRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/RemainRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package team.aliens.data.repository
+
+import team.aliens.data.remote.datasource.declaration.RemoteRemainDataSource
+import team.aliens.data.remote.response.remain.toEntity
+import team.aliens.domain.entity.remain.AvailableRemainTimeEntity
+import team.aliens.domain.entity.remain.CurrentRemainOptionEntity
+import team.aliens.domain.entity.remain.RemainOptionsEntity
+import team.aliens.domain.repository.RemainRepository
+import java.util.*
+import javax.inject.Inject
+
+class RemainRepositoryImpl @Inject constructor(
+    private val remoteRemainDataSource: RemoteRemainDataSource,
+) : RemainRepository {
+
+    override suspend fun updateRemainOption(remainOptionId: UUID) {
+        remoteRemainDataSource.updateRemainOption(
+            remainOptionId = remainOptionId,
+        )
+    }
+
+    override suspend fun fetchCurrentRemainOption(): CurrentRemainOptionEntity {
+        return remoteRemainDataSource.fetchCurrentRemainOption().toEntity()
+    }
+
+    override suspend fun fetchAvailableRemainTime(): AvailableRemainTimeEntity {
+        return remoteRemainDataSource.fetchAvailableRemainTime().toEntity()
+    }
+
+    override suspend fun fetchRemainOptions(): RemainOptionsEntity {
+        return remoteRemainDataSource.fetchRemainOptions().toEntity()
+    }
+}

--- a/di/src/main/java/team/aliens/di/NetWorkModule.kt
+++ b/di/src/main/java/team/aliens/di/NetWorkModule.kt
@@ -10,6 +10,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import team.aliens.data.intercepter.AuthorizationInterceptor
 import team.aliens.data.remote.api.*
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -56,4 +57,8 @@ object NetWorkModule {
     @Provides
     fun provideStudyRoomApi(retrofit: Retrofit): StudyRoomApi =
         retrofit.create(StudyRoomApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideRemainApi(retrofit: Retrofit): RemainApi = retrofit.create(RemainApi::class.java)
 }

--- a/di/src/main/java/team/aliens/di/RepositoryModule.kt
+++ b/di/src/main/java/team/aliens/di/RepositoryModule.kt
@@ -14,6 +14,7 @@ import team.aliens.local_domain.repository.LocalUserRepository
 import team.aliens.local_domain.repository.meal.LocalMealRepository
 import team.aliens.local_domain.repository.mypage.LocalMyPageRepository
 import team.aliens.local_domain.repository.notice.LocalNoticeRepository
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -73,4 +74,10 @@ abstract class RepositoryModule {
     abstract fun provideLocalMyPageRepository(
         localMyPageRepositoryImpl: LocalMyPageRepositoryImpl,
     ): LocalMyPageRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsRemainRepository(
+        remainRepositoryImpl: RemainRepositoryImpl,
+    ): RemainRepository
 }

--- a/domain/src/main/java/team/aliens/domain/entity/remain/AvailableRemainTimeEntity.kt
+++ b/domain/src/main/java/team/aliens/domain/entity/remain/AvailableRemainTimeEntity.kt
@@ -1,0 +1,10 @@
+package team.aliens.domain.entity.remain
+
+import java.time.DayOfWeek
+
+data class AvailableRemainTimeEntity(
+    val startDayOfWeek: DayOfWeek,
+    val startsAt: String,
+    val endDayOfWeek: DayOfWeek,
+    val endsAt: String,
+)

--- a/domain/src/main/java/team/aliens/domain/entity/remain/CurrentRemainOptionEntity.kt
+++ b/domain/src/main/java/team/aliens/domain/entity/remain/CurrentRemainOptionEntity.kt
@@ -1,0 +1,5 @@
+package team.aliens.domain.entity.remain
+
+data class CurrentRemainOptionEntity(
+    val title: String,
+)

--- a/domain/src/main/java/team/aliens/domain/entity/remain/RemainOptionsEntity.kt
+++ b/domain/src/main/java/team/aliens/domain/entity/remain/RemainOptionsEntity.kt
@@ -1,0 +1,14 @@
+package team.aliens.domain.entity.remain
+
+import java.util.*
+
+data class RemainOptionsEntity(
+    val selectedOption: String,
+    val remainOptions: List<RemainOption>,
+) {
+    data class RemainOption(
+        val id: UUID,
+        val title: String,
+        val description: String,
+    )
+}

--- a/domain/src/main/java/team/aliens/domain/entity/remain/RemainOptionsEntity.kt
+++ b/domain/src/main/java/team/aliens/domain/entity/remain/RemainOptionsEntity.kt
@@ -4,9 +4,9 @@ import java.util.*
 
 data class RemainOptionsEntity(
     val selectedOption: String,
-    val remainOptions: List<RemainOption>,
+    val remainOptionEntities: List<RemainOptionEntity>,
 ) {
-    data class RemainOption(
+    data class RemainOptionEntity(
         val id: UUID,
         val title: String,
         val description: String,

--- a/domain/src/main/java/team/aliens/domain/repository/RemainRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/RemainRepository.kt
@@ -7,13 +7,13 @@ import java.util.*
 
 interface RemainRepository {
 
-    fun updateRemainOption(
+    suspend fun updateRemainOption(
         remainOptionId: UUID,
     )
 
-    fun fetchCurrentRemainOption(): CurrentRemainOptionEntity
+    suspend fun fetchCurrentRemainOption(): CurrentRemainOptionEntity
 
-    fun fetchAvailableRemainTime(): AvailableRemainTimeEntity
+    suspend fun fetchAvailableRemainTime(): AvailableRemainTimeEntity
 
-    fun fetchRemainOptions(): RemainOptionsEntity
+    suspend fun fetchRemainOptions(): RemainOptionsEntity
 }

--- a/domain/src/main/java/team/aliens/domain/repository/RemainRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/RemainRepository.kt
@@ -1,0 +1,19 @@
+package team.aliens.domain.repository
+
+import team.aliens.domain.entity.remain.AvailableRemainTimeEntity
+import team.aliens.domain.entity.remain.CurrentRemainOptionEntity
+import team.aliens.domain.entity.remain.RemainOptionsEntity
+import java.util.*
+
+interface RemainRepository {
+
+    fun updateRemainOption(
+        remainOptionId: UUID,
+    )
+
+    fun fetchCurrentRemainOption(): CurrentRemainOptionEntity
+
+    fun fetchAvailableRemainTime(): AvailableRemainTimeEntity
+
+    fun fetchRemainOptions(): RemainOptionsEntity
+}

--- a/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchAvailableRemainTimeUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchAvailableRemainTimeUseCase.kt
@@ -1,0 +1,14 @@
+package team.aliens.domain.usecase.remain
+
+import team.aliens.domain.entity.remain.AvailableRemainTimeEntity
+import team.aliens.domain.repository.RemainRepository
+import team.aliens.domain.usecase.UseCase
+import javax.inject.Inject
+
+class RemoteFetchAvailableRemainTimeUseCase @Inject constructor(
+    private val remainRepository: RemainRepository,
+) : UseCase<Unit, AvailableRemainTimeEntity>() {
+    override suspend fun execute(data: Unit): AvailableRemainTimeEntity {
+        return remainRepository.fetchAvailableRemainTime()
+    }
+}

--- a/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchCurrentRemainOptionsUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchCurrentRemainOptionsUseCase.kt
@@ -1,0 +1,14 @@
+package team.aliens.domain.usecase.remain
+
+import team.aliens.domain.entity.remain.CurrentRemainOptionEntity
+import team.aliens.domain.repository.RemainRepository
+import team.aliens.domain.usecase.UseCase
+import javax.inject.Inject
+
+class RemoteFetchCurrentRemainOptionsUseCase @Inject constructor(
+    private val remainRepository: RemainRepository,
+) : UseCase<Unit, CurrentRemainOptionEntity>() {
+    override suspend fun execute(data: Unit): CurrentRemainOptionEntity {
+        return remainRepository.fetchCurrentRemainOption()
+    }
+}

--- a/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchRemainOptionsUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteFetchRemainOptionsUseCase.kt
@@ -1,0 +1,14 @@
+package team.aliens.domain.usecase.remain
+
+import team.aliens.domain.entity.remain.RemainOptionsEntity
+import team.aliens.domain.repository.RemainRepository
+import team.aliens.domain.usecase.UseCase
+import javax.inject.Inject
+
+class RemoteFetchRemainOptionsUseCase @Inject constructor(
+    private val remainRepository: RemainRepository,
+) : UseCase<Unit, RemainOptionsEntity>() {
+    override suspend fun execute(data: Unit): RemainOptionsEntity {
+        return remainRepository.fetchRemainOptions()
+    }
+}

--- a/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteUpdateRemainOptionUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/remain/RemoteUpdateRemainOptionUseCase.kt
@@ -1,0 +1,16 @@
+package team.aliens.domain.usecase.remain
+
+import team.aliens.domain.repository.RemainRepository
+import team.aliens.domain.usecase.UseCase
+import java.util.*
+import javax.inject.Inject
+
+class RemoteUpdateRemainOptionUseCase @Inject constructor(
+    private val remainRepository: RemainRepository,
+) : UseCase<UUID, Unit>() {
+    override suspend fun execute(remainOptionId: UUID) {
+        remainRepository.updateRemainOption(
+            remainOptionId = remainOptionId,
+        )
+    }
+}


### PR DESCRIPTION
## 개요
> 서버 통신을 위한 추상적인 도메인 엔티티, 리포지토리를 추가하고, 데이터 레이어에서 구현합니다.

## 작업사항
### domain layer
- 잔류에 관한 엔티티 구현
- 잔류에 관한 리포지토리 구현
- 잔류에 관한 유즈케이스 구현

### data layer
- 잔류에 관한 리포지토리 구현체 구현
- 잔류에 관한 API 인터페이스, URL 구현 및 의존성 주입 설정
- 잔류에 관한 DataSource 인터페이스, 구현체 구현 및 의존성 주입 설정

### di layer
- NetworkModule에 RemainApi 제공 로직 구현
- RepositoryModule에 RemainRepository 바인딩 로직 구현

## 추가 로 할 말
