### PR TITLE
🔀 :: (#207) refactor intercepter

### DIFF
--- a/data/src/main/java/team/aliens/data/intercepter/AuthorizationInterceptor.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/AuthorizationInterceptor.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 import team.aliens.data.remote.url.DmsUrl
-import team.aliens.data.remote.url.DmsUrlProperties
+import team.aliens.data.remote.url.DmsHttpProperties
 import team.aliens.data.util.LocalDateTimeEx
 import team.aliens.local_database.localutil.toLocalDateTime
 import team.aliens.local_database.param.UserPersonalKeyParam
@@ -66,8 +66,8 @@ class AuthorizationInterceptor @Inject constructor(
 
         return chain.proceed(
             request.newBuilder().addHeader(
-                DmsUrlProperties.Header.AUTHORIZATION,
-                DmsUrlProperties.Prefix.BEARER + accessToken,
+                DmsHttpProperties.Header.AUTHORIZATION,
+                DmsHttpProperties.Prefix.BEARER + accessToken,
             ).build(),
         )
     }

--- a/data/src/main/java/team/aliens/data/intercepter/OkHttpClientQualifier.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/OkHttpClientQualifier.kt
@@ -1,0 +1,17 @@
+package team.aliens.data.intercepter
+
+import javax.inject.Qualifier
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultOkHttpClient(
+    val value: String = "defaultOkHttpClient",
+)
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+annotation class TokenReissueOkHttpClient(
+    val value: String = "tokenReissueOkHttpClient",
+)

--- a/data/src/main/java/team/aliens/data/intercepter/OkHttpClientQualifier.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/OkHttpClientQualifier.kt
@@ -2,6 +2,10 @@ package team.aliens.data.intercepter
 
 import javax.inject.Qualifier
 
+/**
+ * @author junsuPark
+ * Annotation, should inject global OkHttpClient, calling common APIs.
+ */
 @Qualifier
 @MustBeDocumented
 @Retention(AnnotationRetention.BINARY)
@@ -9,6 +13,10 @@ annotation class DefaultOkHttpClient(
     val value: String = "defaultOkHttpClient",
 )
 
+/**
+ * @author junsuPark
+ * Annotation, should inject OkHttpClient only for reissuing tokens, calling unique reissuing API.
+ */
 @Qualifier
 @MustBeDocumented
 @Retention(AnnotationRetention.BINARY)

--- a/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
@@ -6,7 +6,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import team.aliens.data.remote.response.user.SignInResponse
-import team.aliens.data.remote.url.DmsUrlProperties
+import team.aliens.data.remote.url.DmsHttpProperties
 import team.aliens.domain.exception.NeedLoginException
 import javax.inject.Inject
 
@@ -40,10 +40,10 @@ class TokenReissueClient @Inject constructor(
             reissueUrl,
         ).put(
             "".toRequestBody(
-                DmsUrlProperties.ContentType.APPLICATION_JSON.toMediaTypeOrNull(),
+                DmsHttpProperties.ContentType.APPLICATION_JSON.toMediaTypeOrNull(),
             ),
         ).addHeader(
-            DmsUrlProperties.Header.REFRESH_TOKEN,
+            DmsHttpProperties.Header.REFRESH_TOKEN,
             refreshToken,
         ).build()
     }

--- a/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
@@ -1,0 +1,50 @@
+package team.aliens.data.intercepter
+
+import com.google.gson.Gson
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import team.aliens.data.remote.response.user.SignInResponse
+import team.aliens.data.remote.url.DmsUrlProperties
+import team.aliens.domain.exception.NeedLoginException
+import javax.inject.Inject
+
+class TokenReissueClient @Inject constructor(
+    private val reissueUrl: String,
+) : OkHttpClient() {
+
+    internal operator fun invoke(
+        refreshToken: String?,
+    ): SignInResponse {
+        requireNotNull(refreshToken)
+
+        val tokenReissueRequest = buildTokenReissueRequest(refreshToken)
+
+        val response = newCall(tokenReissueRequest).execute()
+
+        return if (response.isSuccessful) {
+            Gson().fromJson(
+                response.body!!.string(),
+                SignInResponse::class.java,
+            )
+        } else {
+            throw NeedLoginException()
+        }
+    }
+
+    private fun buildTokenReissueRequest(
+        refreshToken: String,
+    ): Request {
+        return Request.Builder().url(
+            reissueUrl,
+        ).put(
+            "".toRequestBody(
+                DmsUrlProperties.ContentType.APPLICATION_JSON.toMediaTypeOrNull(),
+            ),
+        ).addHeader(
+            DmsUrlProperties.Header.REFRESH_TOKEN,
+            refreshToken,
+        ).build()
+    }
+}

--- a/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
+++ b/data/src/main/java/team/aliens/data/intercepter/TokenReissueClient.kt
@@ -24,6 +24,8 @@ class TokenReissueClient @Inject constructor(
         val response = newCall(tokenReissueRequest).execute()
 
         return if (response.isSuccessful) {
+            checkNotNull(response.body)
+
             Gson().fromJson(
                 response.body!!.string(),
                 SignInResponse::class.java,

--- a/data/src/main/java/team/aliens/data/remote/url/DmsHttpProperties.kt
+++ b/data/src/main/java/team/aliens/data/remote/url/DmsHttpProperties.kt
@@ -1,6 +1,6 @@
 package team.aliens.data.remote.url
 
-object DmsUrlProperties {
+object DmsHttpProperties {
 
     object ContentType {
         const val APPLICATION_JSON = "application/json"

--- a/data/src/main/java/team/aliens/data/remote/url/DmsUrlProperties.kt
+++ b/data/src/main/java/team/aliens/data/remote/url/DmsUrlProperties.kt
@@ -1,0 +1,17 @@
+package team.aliens.data.remote.url
+
+object DmsUrlProperties {
+
+    object ContentType {
+        const val APPLICATION_JSON = "application/json"
+    }
+
+    object Header {
+        const val AUTHORIZATION = "Authorization"
+        const val REFRESH_TOKEN = "refresh-token"
+    }
+
+    object Prefix {
+        const val BEARER = "Bearer "
+    }
+}

--- a/di/src/main/java/team/aliens/di/NetWorkModule.kt
+++ b/di/src/main/java/team/aliens/di/NetWorkModule.kt
@@ -24,6 +24,9 @@ object NetWorkModule {
 
     @Provides
     fun provideOkHttpclient(
+    @DefaultOkHttpClient
+    @Provides
+    fun provideDefaultOkHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
         authorizationInterceptor: AuthorizationInterceptor,
     ): OkHttpClient = OkHttpClient.Builder().addInterceptor(httpLoggingInterceptor)
@@ -31,7 +34,7 @@ object NetWorkModule {
 
     @Provides
     fun provideRetrofit(
-        okHttpClient: OkHttpClient,
+        @DefaultOkHttpClient okHttpClient: OkHttpClient,
     ): Retrofit = Retrofit.Builder().baseUrl(BASE_URL).client(okHttpClient)
         .addConverterFactory(GsonConverterFactory.create()).build()
 

--- a/di/src/main/java/team/aliens/di/NetWorkModule.kt
+++ b/di/src/main/java/team/aliens/di/NetWorkModule.kt
@@ -20,7 +20,13 @@ object NetWorkModule {
 
     @Provides
     fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor =
-        HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
+        HttpLoggingInterceptor().setLevel(
+            if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            },
+        )
 
     @Provides
     fun provideOkHttpclient(

--- a/di/src/main/java/team/aliens/di/NetWorkModule.kt
+++ b/di/src/main/java/team/aliens/di/NetWorkModule.kt
@@ -9,7 +9,12 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import team.aliens.data.intercepter.AuthorizationInterceptor
+import team.aliens.data.intercepter.DefaultOkHttpClient
+import team.aliens.data.intercepter.TokenReissueClient
+import team.aliens.data.intercepter.TokenReissueOkHttpClient
 import team.aliens.data.remote.api.*
+import team.aliens.data.remote.url.DmsUrl
+import team.aliens.local_database.storage.declaration.UserDataStorage
 import javax.inject.Singleton
 
 @Module
@@ -29,7 +34,17 @@ object NetWorkModule {
         )
 
     @Provides
-    fun provideOkHttpclient(
+    @Singleton
+    fun providesAuthorizationInterceptor(
+        userDataStorage: UserDataStorage,
+        @TokenReissueOkHttpClient tokenReissueClient: TokenReissueClient,
+    ): AuthorizationInterceptor {
+        return AuthorizationInterceptor(
+            userDataStorage = userDataStorage,
+            tokenReissueClient = tokenReissueClient,
+        )
+    }
+
     @DefaultOkHttpClient
     @Provides
     fun provideDefaultOkHttpClient(
@@ -37,6 +52,12 @@ object NetWorkModule {
         authorizationInterceptor: AuthorizationInterceptor,
     ): OkHttpClient = OkHttpClient.Builder().addInterceptor(httpLoggingInterceptor)
         .addInterceptor(authorizationInterceptor).build()
+
+    @TokenReissueOkHttpClient
+    @Provides
+    @Singleton
+    fun providesTokenReissueOkHttpClient(): TokenReissueClient =
+        TokenReissueClient(BASE_URL + DmsUrl.User.refreshToken)
 
     @Provides
     fun provideRetrofit(
@@ -55,13 +76,16 @@ object NetWorkModule {
     fun provideMealApi(retrofit: Retrofit): MealApi = retrofit.create(MealApi::class.java)
 
     @Provides
-    fun provideNoticeApi(retrofit: Retrofit): NoticeApi = retrofit.create(NoticeApi::class.java)
+    fun provideNoticeApi(retrofit: Retrofit): NoticeApi =
+        retrofit.create(NoticeApi::class.java)
 
     @Provides
-    fun provideSchoolsApi(retrofit: Retrofit): SchoolsApi = retrofit.create(SchoolsApi::class.java)
+    fun provideSchoolsApi(retrofit: Retrofit): SchoolsApi =
+        retrofit.create(SchoolsApi::class.java)
 
     @Provides
-    fun provideMyPageApi(retrofit: Retrofit): MyPageApi = retrofit.create(MyPageApi::class.java)
+    fun provideMyPageApi(retrofit: Retrofit): MyPageApi =
+        retrofit.create(MyPageApi::class.java)
 
     @Provides
     fun provideStudyRoomApi(retrofit: Retrofit): StudyRoomApi =
@@ -69,5 +93,6 @@ object NetWorkModule {
 
     @Provides
     @Singleton
-    fun provideRemainApi(retrofit: Retrofit): RemainApi = retrofit.create(RemainApi::class.java)
+    fun provideRemainApi(retrofit: Retrofit): RemainApi =
+        retrofit.create(RemainApi::class.java)
 }

--- a/local_database/src/main/java/team/aliens/local_database/storage/implementation/UserDataStorageImpl.kt
+++ b/local_database/src/main/java/team/aliens/local_database/storage/implementation/UserDataStorageImpl.kt
@@ -7,29 +7,47 @@ import team.aliens.local_database.param.FeaturesParam
 import team.aliens.local_database.param.UserPersonalKeyParam
 import team.aliens.local_database.param.user.UserInfoParam
 import team.aliens.local_database.storage.declaration.UserDataStorage
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserInfo.ID
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserInfo.PASSWORD
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserPersonalKey.ACCESS_TOKEN
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserPersonalKey.ACCESS_TOKEN_EXPIRED_AT
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserPersonalKey.REFRESH_TOKEN
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserPersonalKey.REFRESH_TOKEN_EXPIRED_AT
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserVisible.MEAL
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserVisible.NOTICE
-import team.aliens.local_database.storage.implementation.UserDataStorageImpl.UserVisible.POINT
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserInfo.ID
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserInfo.PASSWORD
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserPersonalKey.ACCESS_TOKEN
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserPersonalKey.ACCESS_TOKEN_EXPIRED_AT
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserPersonalKey.REFRESH_TOKEN
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserPersonalKey.REFRESH_TOKEN_EXPIRED_AT
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserVisible.MEAL
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserVisible.NOTICE
+import team.aliens.local_database.storage.implementation.UserDataStorageImpl.Companion.UserVisible.POINT
 import javax.inject.Inject
 
 class UserDataStorageImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : UserDataStorage {
 
-    companion object {
+    private companion object {
+
         const val USER_DATA_STORAGE_KEY = "user_data_storage"
+
+        object UserInfo {
+            const val ID = "ID"
+            const val PASSWORD = "PASSWORD"
+        }
+
+        object UserPersonalKey {
+            const val ACCESS_TOKEN = "ACCESS_TOKEN"
+            const val ACCESS_TOKEN_EXPIRED_AT = "ACCESS_TOKEN_EXPIRED_AT"
+            const val REFRESH_TOKEN = "REFRESH_TOKEN"
+            const val REFRESH_TOKEN_EXPIRED_AT = "REFRESH_TOKEN_EXPIRED_AT"
+        }
+
+        object UserVisible {
+            const val MEAL = "MEAL"
+            const val NOTICE = "NOTICE"
+            const val POINT = "POINT"
+        }
     }
 
     private val prefs: SharedPreferences
-        get() = run {
-            context.getSharedPreferences(USER_DATA_STORAGE_KEY, Context.MODE_PRIVATE)!!
-        }
+        get() = context.getSharedPreferences(USER_DATA_STORAGE_KEY, Context.MODE_PRIVATE)
+            ?: throw IllegalStateException()
 
     private val editor: SharedPreferences.Editor
         get() = prefs.edit()
@@ -60,9 +78,7 @@ class UserDataStorageImpl @Inject constructor(
     }
 
     override fun clearToken() {
-        editor.run {
-            clear()
-        }.apply()
+        editor.clear().apply()
     }
 
     override fun setUserVisible(featuresParam: FeaturesParam) {
@@ -99,23 +115,5 @@ class UserDataStorageImpl @Inject constructor(
 
     override fun fetchPassword(): String {
         return prefs.getString(PASSWORD, "")!!
-    }
-
-    private object UserInfo {
-        const val ID = "ID"
-        const val PASSWORD = "PASSWORD"
-    }
-
-    private object UserPersonalKey {
-        const val ACCESS_TOKEN = "ACCESS_TOKEN"
-        const val ACCESS_TOKEN_EXPIRED_AT = "ACCESS_TOKEN_EXPIRED_AT"
-        const val REFRESH_TOKEN = "REFRESH_TOKEN"
-        const val REFRESH_TOKEN_EXPIRED_AT = "REFRESH_TOKEN_EXPIRED_AT"
-    }
-
-    private object UserVisible {
-        const val MEAL = "MEAL"
-        const val NOTICE = "NOTICE"
-        const val POINT = "POINT"
     }
 }

--- a/local_database/src/main/java/team/aliens/local_database/storage/implementation/UserDataStorageImpl.kt
+++ b/local_database/src/main/java/team/aliens/local_database/storage/implementation/UserDataStorageImpl.kt
@@ -1,6 +1,5 @@
 package team.aliens.local_database.storage.implementation
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -23,89 +22,83 @@ class UserDataStorageImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : UserDataStorage {
 
-    @SuppressLint("CommitPrefEdits")
-    override fun setPersonalKey(personalKeyParam: UserPersonalKeyParam) {
-        setString(context, ACCESS_TOKEN, personalKeyParam.accessToken)
-        setString(
-            context,
-            ACCESS_TOKEN_EXPIRED_AT,
-            personalKeyParam.accessTokenExpiredAt.toString()
-        )
-        setString(context, REFRESH_TOKEN, personalKeyParam.refreshToken)
-        setString(
-            context,
-            REFRESH_TOKEN_EXPIRED_AT,
-            personalKeyParam.refreshTokenExpiredAt.toString()
-        )
+    companion object {
+        const val USER_DATA_STORAGE_KEY = "user_data_storage"
     }
 
-    override fun fetchAccessToken(): String = getString(context, ACCESS_TOKEN)!!
+    private val prefs: SharedPreferences
+        get() = run {
+            context.getSharedPreferences(USER_DATA_STORAGE_KEY, Context.MODE_PRIVATE)!!
+        }
+
+    private val editor: SharedPreferences.Editor
+        get() = prefs.edit()
+
+    override fun setPersonalKey(personalKeyParam: UserPersonalKeyParam) {
+        editor.run {
+            putString(ACCESS_TOKEN, personalKeyParam.accessToken)
+            putString(ACCESS_TOKEN_EXPIRED_AT, personalKeyParam.accessTokenExpiredAt.toString())
+            putString(REFRESH_TOKEN, personalKeyParam.refreshToken)
+            putString(REFRESH_TOKEN_EXPIRED_AT, personalKeyParam.refreshTokenExpiredAt.toString())
+        }.apply()
+    }
+
+    override fun fetchAccessToken(): String {
+        return prefs.getString(ACCESS_TOKEN, "")!!
+    }
 
     override fun fetchAccessTokenExpiredAt(): String {
-        return getString(context, ACCESS_TOKEN_EXPIRED_AT)!!
+        return prefs.getString(ACCESS_TOKEN_EXPIRED_AT, "")!!
     }
 
-    override fun fetchRefreshToken(): String = getString(context, REFRESH_TOKEN)!!
+    override fun fetchRefreshToken(): String {
+        return prefs.getString(REFRESH_TOKEN, "")!!
+    }
 
-    override fun fetchRefreshTokenExpiredAt(): String =
-        getString(context, REFRESH_TOKEN_EXPIRED_AT)!!
+    override fun fetchRefreshTokenExpiredAt(): String {
+        return prefs.getString(REFRESH_TOKEN_EXPIRED_AT, "")!!
+    }
 
     override fun clearToken() {
-        setString(context, ACCESS_TOKEN, "")
-        setString(context, ACCESS_TOKEN_EXPIRED_AT, "")
-        setString(context, REFRESH_TOKEN, "")
-        setString(context, REFRESH_TOKEN_EXPIRED_AT, "")
+        editor.run {
+            clear()
+        }.apply()
     }
 
     override fun setUserVisible(featuresParam: FeaturesParam) {
-        setBoolean(context, MEAL, featuresParam.mealService)
-        setBoolean(context, NOTICE, featuresParam.noticeService)
-        setBoolean(context, POINT, featuresParam.pointService)
+        editor.run {
+            putBoolean(MEAL, featuresParam.mealService)
+            putBoolean(NOTICE, featuresParam.noticeService)
+            putBoolean(POINT, featuresParam.pointService)
+        }.apply()
     }
 
-    override fun fetchMealServiceBoolean(): Boolean = getBoolean(context, MEAL)
+    override fun fetchMealServiceBoolean(): Boolean {
+        return prefs.getBoolean(MEAL, false)
+    }
 
-    override fun fetchNoticeServiceBoolean(): Boolean = getBoolean(context, NOTICE)
+    override fun fetchNoticeServiceBoolean(): Boolean {
+        return prefs.getBoolean(NOTICE, false)
+    }
 
-    override fun fetchPointServiceBoolean(): Boolean = getBoolean(context, POINT)
+    override fun fetchPointServiceBoolean(): Boolean {
+        return prefs.getBoolean(POINT, false)
+    }
 
     override fun setUserInfo(userInfoParam: UserInfoParam) {
-        setString(context, ID, userInfoParam.id)
-        setString(context, PASSWORD, userInfoParam.password)
+        editor.run {
+            putString(ID, userInfoParam.id)
+            putString(PASSWORD, userInfoParam.password)
+        }.apply()
     }
 
-    override fun fetchId(): String = getString(context, ID)!!
-
-
-    override fun fetchPassword(): String = getString(context, PASSWORD)!!
-
-
-    private fun getPreferences(key: String?, context: Context): SharedPreferences? {
-        return context.getSharedPreferences(key, Context.MODE_PRIVATE)
+    override fun fetchId(): String {
+        return prefs.getString(ID, "")!!
     }
 
-    private fun setString(context: Context?, key: String?, value: String?) {
-        val prefs: SharedPreferences = context?.let { getPreferences(key, it) }!!
-        val editor = prefs.edit()
-        editor.putString(key, value)
-        editor.apply()
-    }
 
-    private fun setBoolean(context: Context?, key: String?, value: Boolean) {
-        val prefs = context?.let { getPreferences(key, it) }
-        val editor = prefs!!.edit()
-        editor.putBoolean(key, value)
-        editor.apply()
-    }
-
-    private fun getString(context: Context?, key: String?): String? {
-        val prefs = context?.let { getPreferences(key, it) }
-        return prefs!!.getString(key, "")
-    }
-
-    private fun getBoolean(context: Context?, key: String?): Boolean {
-        val prefs = context?.let { getPreferences(key, it) }
-        return prefs!!.getBoolean(key, false)
+    override fun fetchPassword(): String {
+        return prefs.getString(PASSWORD, "")!!
     }
 
     private object UserInfo {


### PR DESCRIPTION
## 개요
> 토큰 저장 오류 및 BASE_URL이 노출되던 기존의 Interceptor를 리팩터합니다.

## 작업사항
- 토큰 재발급을 위한 OkHttpClient 하위 구현체인 `TokenReissueClient`를 구현하였습니다
- `AuthorizationInterceptor`에서 `TokenReissueClient`를 주입받아, 토큰 재발급이 필요한 시점에 해당 Client를 Invoke하여 토큰 리스폰스(`SignInResponse`)를 전달받으며, 해당 정보를 로컬 데이터베이스에 저장합니다

## 추가 로 할 말
- 아직 할 일이 많이 남아 있어욥..