### PR TITLE
🔀 :: (#210) implement floating notice click event

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
@@ -6,10 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.paint
@@ -18,7 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
@@ -30,13 +27,16 @@ import team.aliens.design_system.toast.rememberToast
 import team.aliens.design_system.typography.Body5
 import team.aliens.design_system.typography.SubTitle1
 import team.aliens.dms_android.component.FloatingNotice
+import team.aliens.dms_android.feature.navigator.BottomNavigationItem
+import team.aliens.dms_android.feature.navigator.navigateBottomNavigation
 import team.aliens.dms_android.viewmodel.home.MealViewModel
 import team.aliens.presentation.R
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun CafeteriaScreen(
-    onNoticeIconClick: () -> Unit,
+    navController: NavHostController,
+    bottomTabSelectedItem: MutableState<String>,
     mealViewModel: MealViewModel = hiltViewModel(),
 ) {
 
@@ -72,7 +72,15 @@ fun CafeteriaScreen(
         Spacer(modifier = Modifier.height(20.dp))
         TopBar()
         Spacer(modifier = Modifier.height(25.dp))
-        ImportantNotice(onNoticeIconClick = onNoticeIconClick)
+        ImportantNotice(
+            onNoticeIconClick = {
+                navigateBottomNavigation(
+                    route = BottomNavigationItem.Notice.route,
+                    navController = navController,
+                )
+                bottomTabSelectedItem.value = BottomNavigationItem.Notice.route
+            }
+        )
         CafeteriaDiary(pagerState = pagerState, coroutineScope = coroutineScope, hiltViewModel())
         CafeteriaViewPager(mealViewModel)
     }
@@ -113,7 +121,7 @@ fun ImportantNotice(
                 .size(33.dp)
                 .dormClickable(
                     rippleEnabled = false,
-                ){
+                ) {
                     onNoticeIconClick()
                 },
             painter = painterResource(id = R.drawable.ic_next),

--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
@@ -36,7 +36,7 @@ import team.aliens.presentation.R
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun CafeteriaScreen(
-    moveToNoticeScreen: () -> Unit,
+    onNoticeIconClick: () -> Unit,
     mealViewModel: MealViewModel = hiltViewModel(),
 ) {
 
@@ -72,7 +72,7 @@ fun CafeteriaScreen(
         Spacer(modifier = Modifier.height(20.dp))
         TopBar()
         Spacer(modifier = Modifier.height(25.dp))
-        ImportantNotice(moveToNoticeScreen)
+        ImportantNotice(onNoticeIconClick = onNoticeIconClick)
         CafeteriaDiary(pagerState = pagerState, coroutineScope = coroutineScope, hiltViewModel())
         CafeteriaViewPager(mealViewModel)
     }
@@ -99,7 +99,7 @@ fun TopBar(
 
 @Composable
 fun ImportantNotice(
-    moveToNoticeScreen: () -> Unit,
+    onNoticeIconClick: () -> Unit,
 ) {
     Box(
         contentAlignment = Alignment.CenterEnd,
@@ -114,7 +114,7 @@ fun ImportantNotice(
                 .dormClickable(
                     rippleEnabled = false,
                 ){
-                    moveToNoticeScreen()
+                    onNoticeIconClick()
                 },
             painter = painterResource(id = R.drawable.ic_next),
             contentDescription = stringResource(id = R.string.IcNotice),

--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/CafeteriaScreen.kt
@@ -25,6 +25,7 @@ import com.google.accompanist.pager.rememberPagerState
 import kotlinx.coroutines.CoroutineScope
 import team.aliens.design_system.color.DormColor
 import team.aliens.design_system.icon.DormIcon
+import team.aliens.design_system.modifier.dormClickable
 import team.aliens.design_system.toast.rememberToast
 import team.aliens.design_system.typography.Body5
 import team.aliens.design_system.typography.SubTitle1
@@ -35,7 +36,7 @@ import team.aliens.presentation.R
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun CafeteriaScreen(
-    navController: NavController,
+    moveToNoticeScreen: () -> Unit,
     mealViewModel: MealViewModel = hiltViewModel(),
 ) {
 
@@ -71,7 +72,7 @@ fun CafeteriaScreen(
         Spacer(modifier = Modifier.height(20.dp))
         TopBar()
         Spacer(modifier = Modifier.height(25.dp))
-        ImportantNotice()
+        ImportantNotice(moveToNoticeScreen)
         CafeteriaDiary(pagerState = pagerState, coroutineScope = coroutineScope, hiltViewModel())
         CafeteriaViewPager(mealViewModel)
     }
@@ -97,17 +98,24 @@ fun TopBar(
 }
 
 @Composable
-fun ImportantNotice() {
+fun ImportantNotice(
+    moveToNoticeScreen: () -> Unit,
+) {
     Box(
         contentAlignment = Alignment.CenterEnd,
         modifier = Modifier.padding(horizontal = 20.dp),
     ) {
         // TODO string resource 로 빼주기
-        FloatingNotice(content = "새로운 공지사항이 있습니다.")
+        FloatingNotice(content = stringResource(id = R.string.NewNotice))
         Image(
             modifier = Modifier
                 .padding(end = 10.dp)
-                .size(33.dp),
+                .size(33.dp)
+                .dormClickable(
+                    rippleEnabled = false,
+                ){
+                    moveToNoticeScreen()
+                },
             painter = painterResource(id = R.drawable.ic_next),
             contentDescription = stringResource(id = R.string.IcNotice),
         )

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/BottomNavigationItem.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/BottomNavigationItem.kt
@@ -4,20 +4,28 @@ import team.aliens.presentation.R
 
 sealed class BottomNavigationItem(var route: String, var iconResId: Int, var title: String) {
     object Meal :
-        BottomNavigationItem(NavigationRoute.BottomNavigation.Meal, R.drawable.ic_house, "Meal")
+        BottomNavigationItem(
+            route = NavigationRoute.BottomNavigation.Meal,
+            iconResId = R.drawable.ic_house,
+            title = "Meal",
+        )
 
     object Application :
-        BottomNavigationItem(NavigationRoute.BottomNavigation.Application, R.drawable.ic_plus, "Application")
+        BottomNavigationItem(
+            route = NavigationRoute.BottomNavigation.Application,
+            iconResId = R.drawable.ic_plus,
+            title = "Application",
+        )
 
     object Notice : BottomNavigationItem(
-        NavigationRoute.BottomNavigation.Notice,
-        R.drawable.ic_notice,
-        "Notice"
+        route = NavigationRoute.BottomNavigation.Notice,
+        iconResId = R.drawable.ic_notice,
+        title = "Notice",
     )
 
     object MyPage : BottomNavigationItem(
-        NavigationRoute.BottomNavigation.MyPage,
-        R.drawable.ic_mypage,
-        "MyPage"
+        route = NavigationRoute.BottomNavigation.MyPage,
+        iconResId = R.drawable.ic_mypage,
+        title = "MyPage",
     )
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
@@ -32,9 +33,16 @@ fun DmsApp(
 ) {
     val navHostController = rememberNavController()
 
+    val bottomTabSelectedItem = rememberSaveable {
+        mutableStateOf(BottomNavigationItem.Meal.route)
+    }
+
     Scaffold(
         scaffoldState = scaffoldState,
-        bottomBar = { BottomNavBar(navController = navHostController) },
+        bottomBar = { BottomNavBar(
+            navController = navHostController,
+            bottomTabSelectedItem = bottomTabSelectedItem,
+        ) },
         modifier = Modifier.background(DormColor.Gray900),
     ) { innerPadding ->
         NavHost(
@@ -42,7 +50,12 @@ fun DmsApp(
             startDestination = BottomNavigationItem.Meal.route,
             modifier = Modifier.padding(innerPadding),
         ) {
-            composable(BottomNavigationItem.Meal.route) { CafeteriaScreen(navController = navController) }
+            composable(BottomNavigationItem.Meal.route) {
+                CafeteriaScreen(moveToNoticeScreen = {
+                    navigateBottomNavigation(BottomNavigationItem.Notice.route, navHostController)
+                    bottomTabSelectedItem.value = BottomNavigationItem.Notice.route
+                })
+            }
             composable(BottomNavigationItem.Application.route) { ApplicationScreen(navController = navController) }
             composable(BottomNavigationItem.Notice.route) { NoticeScreen(navController = navController) }
             composable(BottomNavigationItem.MyPage.route) {
@@ -55,14 +68,12 @@ fun DmsApp(
 @Composable
 fun BottomNavBar(
     navController: NavHostController,
+    bottomTabSelectedItem: MutableState<String>,
 ) = BottomAppBar(
     cutoutShape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),
     backgroundColor = MaterialTheme.colors.background,
     contentColor = DormColor.Gray900,
 ) {
-    val bottomTabSelectedItem = rememberSaveable {
-        mutableStateOf(BottomNavigationItem.Meal.route)
-    }
     BottomNavigationItem(modifier = Modifier
         .weight(0.5f)
         .size(25.dp), onClick = {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
@@ -54,13 +54,8 @@ fun DmsApp(
         ) {
             composable(BottomNavigationItem.Meal.route) {
                 CafeteriaScreen(
-                    onNoticeIconClick = {
-                        navigateBottomNavigation(
-                            route = BottomNavigationItem.Notice.route,
-                            navController = navHostController,
-                        )
-                        bottomTabSelectedItem.value = BottomNavigationItem.Notice.route
-                    },
+                    navController = navHostController,
+                    bottomTabSelectedItem = bottomTabSelectedItem,
                 )
             }
             composable(BottomNavigationItem.Application.route) { ApplicationScreen(navController = navController) }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
@@ -39,10 +39,12 @@ fun DmsApp(
 
     Scaffold(
         scaffoldState = scaffoldState,
-        bottomBar = { BottomNavBar(
-            navController = navHostController,
-            bottomTabSelectedItem = bottomTabSelectedItem,
-        ) },
+        bottomBar = {
+            BottomNavBar(
+                navController = navHostController,
+                bottomTabSelectedItem = bottomTabSelectedItem,
+            )
+        },
         modifier = Modifier.background(DormColor.Gray900),
     ) { innerPadding ->
         NavHost(
@@ -51,10 +53,15 @@ fun DmsApp(
             modifier = Modifier.padding(innerPadding),
         ) {
             composable(BottomNavigationItem.Meal.route) {
-                CafeteriaScreen(moveToNoticeScreen = {
-                    navigateBottomNavigation(BottomNavigationItem.Notice.route, navHostController)
-                    bottomTabSelectedItem.value = BottomNavigationItem.Notice.route
-                })
+                CafeteriaScreen(
+                    onNoticeIconClick = {
+                        navigateBottomNavigation(
+                            route = BottomNavigationItem.Notice.route,
+                            navController = navHostController,
+                        )
+                        bottomTabSelectedItem.value = BottomNavigationItem.Notice.route
+                    },
+                )
             }
             composable(BottomNavigationItem.Application.route) { ApplicationScreen(navController = navController) }
             composable(BottomNavigationItem.Notice.route) { NoticeScreen(navController = navController) }


### PR DESCRIPTION
## 개요
> 급식 화면의 공지 알림 컴포넌트 아이콘을 클릭했을때 공지 화면으로 전환되는 로직을 구현했습니다.

## 작업사항
- CafeterialScreen 파라미터로 moveToNoticeScreen 함수 추가
- bottomSelectedItem 값 BottomNavBar 함수에서 DmsApp 함수로 이동
- 공지 화면으로 이동 시 공지 바텀 아이템 선택 효과 구현

## 추가 로 할 말
- 추후에 공지 알림을 상황에 따라 표시해주는 로직 구현이 필요할것 같습니다.
- ex 공지가 없는 경우 공지 알림 표시 X
- ex 유저가 공지 알림을 통해 새 공지를 확인한 경우 공지 알림 표시 X
