### PR TITLE
🔀 :: (#208) fix screen remaining bug when back button pressed

### DIFF
--- a/di/src/main/java/team/aliens/di/NetWorkModule.kt
+++ b/di/src/main/java/team/aliens/di/NetWorkModule.kt
@@ -21,7 +21,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetWorkModule {
 
-    private const val BASE_URL = ""
+    private const val BASE_URL = "http://3.39.162.197:8080"
 
     @Provides
     fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor =

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -1,15 +1,11 @@
 package team.aliens.dms_android.feature.auth.login
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.ScaffoldState
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -34,7 +30,6 @@ import team.aliens.presentation.R
 
 @Composable
 fun LoginScreen(
-    scaffoldState: ScaffoldState,
     navController: NavController,
     signInViewModel: SignInViewModel = hiltViewModel(),
 ) {
@@ -198,10 +193,41 @@ fun LoginScreen(
             )
         }
 
-        LoginButton(signInViewModel, scaffoldState)
-    }
+        Spacer(
+            modifier = Modifier.weight(1f),
+        )
 
-    BackPressHandle()
+        DormContainedLargeButton(
+            text = stringResource(id = R.string.Login),
+            color = DormButtonColor.Blue,
+            onClick = {
+
+                if (signInViewModel.state.value.id.isBlank()) {
+
+                    toast(
+                        context.getString(R.string.PleaseEnterId)
+                    )
+
+                    return@DormContainedLargeButton
+                }
+
+                if (signInViewModel.state.value.password.isBlank()) {
+
+                    toast(
+                        context.getString(R.string.PleaseEnterPassword)
+                    )
+
+                    return@DormContainedLargeButton
+                }
+
+                signInViewModel.postSignIn()
+            },
+        )
+
+        Spacer(
+            modifier = Modifier.height(57.dp),
+        )
+    }
 }
 
 private fun getStringFromEvent(
@@ -220,39 +246,4 @@ private fun getStringFromEvent(
             else -> throw IllegalArgumentException()
         },
     )
-}
-
-@Composable
-private fun BackPressHandle() {
-    val backHandlingEnabled by remember { mutableStateOf(true) }
-    val activity = (LocalContext.current as Activity)
-    BackHandler(backHandlingEnabled) {
-        activity.finish()
-    }
-}
-
-@Composable
-fun LoginButton(
-    signInViewModel: SignInViewModel,
-    scaffoldState: ScaffoldState,
-) {
-
-    Box(
-        contentAlignment = Alignment.BottomCenter,
-        modifier = Modifier
-            .padding(
-                start = 16.dp,
-                end = 16.dp,
-                bottom = 60.dp,
-            )
-            .fillMaxSize(),
-    ) {
-        DormContainedLargeButton(text = stringResource(id = R.string.Login),
-            color = DormButtonColor.Blue,
-            onClick = {
-                if (signInViewModel.state.value.id != "" && signInViewModel.state.value.password != "") {
-                    signInViewModel.postSignIn()
-                }
-            })
-    }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -105,22 +105,23 @@ private fun BackPressHandle() {
 
 @Composable
 fun MainTitle() {
-    Box(contentAlignment = Alignment.TopStart) {
-        Column(
-            modifier = Modifier.padding(start = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Image(
-                modifier = Modifier
-                    .padding(top = 92.dp)
-                    .height(34.dp)
-                    .width(97.dp),
-                painter = painterResource(id = R.drawable.ic_logo),
-                contentDescription = stringResource(id = R.string.MainLogo),
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Body4(text = stringResource(id = R.string.AppDescription))
-        }
+    Column(
+        modifier = Modifier.padding(start = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Image(
+            modifier = Modifier
+                .padding(top = 92.dp)
+                .height(34.dp)
+                .width(97.dp),
+            painter = painterResource(id = R.drawable.ic_logo),
+            contentDescription = null,
+        )
+        Body4(
+            text = stringResource(
+                id = R.string.AppDescription,
+            ),
+        )
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -61,15 +61,82 @@ fun LoginScreen(
         }
     }
 
+    var idState by remember {
+        mutableStateOf("")
+    }
+
+    val onIdChange = { value: String ->
+        idState = value
+        signInViewModel.setId(value)
+    }
+
+    var passwordState by remember {
+        mutableStateOf("")
+    }
+
+    val onPasswordChange = { value: String ->
+        passwordState = value
+        signInViewModel.setPassword(value)
+    }
+
+    var autoLoginState by remember {
+        mutableStateOf(false)
+    }
+
+    val onAutoLoginStateChange = { value: Boolean ->
+        autoLoginState = value
+        signInViewModel.state.value.autoLogin = value
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = DormColor.Gray100),
+            .background(color = DormColor.Gray100)
+            .padding(
+                top = 92.dp,
+                start = 16.dp,
+                end = 16.dp,
+            ),
     ) {
+
         MainTitle()
-        TextField(signInViewModel)
-        AutoLogin(signInViewModel)
+
+        Spacer(
+            modifier = Modifier.height(52.dp),
+        )
+
+        DormTextField(
+            value = idState,
+            onValueChange = onIdChange,
+            hint = stringResource(id = R.string.ID),
+        )
+
+        Spacer(
+            modifier = Modifier.height(36.dp),
+        )
+
+        DormTextField(
+            value = passwordState,
+            onValueChange = onPasswordChange,
+            isPassword = true,
+            hint = stringResource(id = R.string.Password),
+        )
+
+        Spacer(
+            modifier = Modifier.height(30.dp),
+        )
+
+        DormTextCheckBox(
+            modifier = Modifier.padding(
+                start = 6.dp,
+            ),
+            text = stringResource(id = R.string.AutoLogin),
+            checked = autoLoginState,
+            onCheckedChange = onAutoLoginStateChange,
+        )
+
         AddFunction()
+
         LoginButton(signInViewModel, scaffoldState)
     }
 
@@ -106,12 +173,10 @@ private fun BackPressHandle() {
 @Composable
 fun MainTitle() {
     Column(
-        modifier = Modifier.padding(start = 16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Image(
             modifier = Modifier
-                .padding(top = 92.dp)
                 .height(34.dp)
                 .width(97.dp),
             painter = painterResource(id = R.drawable.ic_logo),
@@ -122,73 +187,6 @@ fun MainTitle() {
                 id = R.string.AppDescription,
             ),
         )
-    }
-}
-
-@Composable
-fun TextField(
-    signInViewModel: SignInViewModel,
-) {
-
-    var idValue by remember { mutableStateOf("") }
-    var passwordValue by remember { mutableStateOf("") }
-
-    Box(contentAlignment = Alignment.TopStart) {
-        Column(
-            modifier = Modifier.padding(start = 16.dp, top = 6.dp, end = 16.dp),
-        ) {
-            Spacer(
-                modifier = Modifier.height(52.dp),
-            )
-            DormTextField(
-                value = idValue,
-                onValueChange = {
-                    idValue = it
-                    signInViewModel.setId(idValue)
-                },
-                hint = stringResource(id = R.string.Login),
-            )
-            Spacer(
-                modifier = Modifier.height(36.dp),
-            )
-            DormTextField(
-                value = passwordValue,
-                onValueChange = {
-                    passwordValue = it
-                    signInViewModel.setPassword(passwordValue)
-                },
-                isPassword = true,
-                hint = stringResource(id = R.string.Password),
-            )
-        }
-    }
-}
-
-@Composable
-fun AutoLogin(
-    signInViewModel: SignInViewModel,
-) {
-
-    var checked by remember { mutableStateOf(false) }
-
-    Box(
-        contentAlignment = Alignment.TopStart,
-    ) {
-        Column(
-            modifier = Modifier.padding(start = 22.dp),
-        ) {
-            Spacer(
-                modifier = Modifier.height(25.dp),
-            )
-            DormTextCheckBox(
-                text = stringResource(id = R.string.AutoLogin),
-                checked = checked,
-                onCheckedChange = {
-                    checked = !checked
-                    signInViewModel.state.value.autoLogin = checked
-                },
-            )
-        }
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -1,6 +1,7 @@
 package team.aliens.dms_android.feature.auth.login
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
@@ -40,46 +41,21 @@ fun LoginScreen(
 
     val toast = rememberToast()
 
-    val badRequestComment = stringResource(id = R.string.BadRequest)
-    val unAuthorizedComment = stringResource(id = R.string.LoginUnAuthorized)
-    val notFoundComment = stringResource(id = R.string.LoginNotFound)
-    val tooManyRequestComment = stringResource(id = R.string.TooManyRequest)
-    val serverException = stringResource(id = R.string.ServerException)
-    val noInternetException = stringResource(id = R.string.NoInternetException)
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        signInViewModel.signInViewEffect.collect {
-            when (it) {
-                is Event.NavigateToHome -> {
+        signInViewModel.signInViewEffect.collect { event ->
+            when (event) {
+                Event.NavigateToHome -> {
                     navController.navigate(route = NavigationRoute.Main)
                 }
-
-                is Event.WrongRequest -> {
-                    toast(badRequestComment)
-                }
-
-                is Event.NotCorrectPassword -> {
-                    toast(unAuthorizedComment)
-                }
-
-                is Event.UserNotFound -> {
-                    toast(notFoundComment)
-                }
-
-                is Event.TooManyRequest -> {
-                    toast(tooManyRequestComment)
-                }
-
-                is Event.ServerException -> {
-                    toast(serverException)
-                }
-
-                is Event.NoInternetException -> {
-                    toast(noInternetException)
-                }
-
-                is Event.UnKnownException -> {
-                    toast(noInternetException)
+                else -> {
+                    toast(
+                        getStringFromEvent(
+                            context = context,
+                            event = event,
+                        ),
+                    )
                 }
             }
         }
@@ -100,12 +76,30 @@ fun LoginScreen(
     BackPressHandle()
 }
 
+private fun getStringFromEvent(
+    context: Context,
+    event: Event,
+): String {
+    return context.getString(
+        when (event) {
+            Event.WrongRequest -> R.string.BadRequest
+            Event.NotCorrectPassword -> R.string.CheckPassword
+            Event.UserNotFound -> R.string.LoginNotFound
+            Event.TooManyRequest -> R.string.TooManyRequest
+            Event.ServerException -> R.string.ServerException
+            Event.NoInternetException -> R.string.NoInternetException
+            Event.UnKnownException -> R.string.UnKnownException
+            else -> throw IllegalArgumentException()
+        },
+    )
+}
+
 @Composable
 private fun BackPressHandle() {
     val backHandlingEnabled by remember { mutableStateOf(true) }
-    val activity = (LocalContext.current as? Activity)
+    val activity = (LocalContext.current as Activity)
     BackHandler(backHandlingEnabled) {
-        activity?.finish()
+        activity.finish()
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -151,7 +151,52 @@ fun LoginScreen(
             onCheckedChange = onAutoLoginStateChange,
         )
 
-        AuthOption()
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentWidth(CenterHorizontally)
+                .padding(
+                    start = 10.dp,
+                    top = 24.dp,
+                    end = 10.dp,
+                ),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+
+            Caption(
+                text = stringResource(id = R.string.DoRegister),
+                onClick = {
+                    context.startActivity(
+                        Intent(
+                            context,
+                            RegisterActivity::class.java,
+                        ),
+                    )
+                },
+            )
+
+            Caption(text = "|")
+
+            Caption(
+                text = stringResource(
+                    id = R.string.FindId,
+                ),
+                onClick = {
+                    // todo implement and link find id screen
+                },
+            )
+
+            Caption(text = "|")
+
+            Caption(
+                text = stringResource(
+                    id = R.string.ChangePassword,
+                ),
+                onClick = {
+                    navController.navigate(NavigationRoute.ChangePassword)
+                },
+            )
+        }
 
         LoginButton(signInViewModel, scaffoldState)
     }
@@ -183,56 +228,6 @@ private fun BackPressHandle() {
     val activity = (LocalContext.current as Activity)
     BackHandler(backHandlingEnabled) {
         activity.finish()
-    }
-}
-
-@Composable
-fun AuthOption() {
-
-    val mContext = LocalContext.current
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentWidth(CenterHorizontally)
-            .padding(
-                start = 10.dp,
-                top = 24.dp,
-                end = 10.dp,
-            ),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-
-        Caption(
-            text = stringResource(id = R.string.DoRegister),
-            onClick = {
-                mContext.startActivity(
-                    Intent(
-                        mContext,
-                        RegisterActivity::class.java,
-                    ),
-                )
-            },
-        )
-
-        Caption(text = "|")
-
-        Caption(
-            text = stringResource(
-                id = R.string.FindId,
-            ),
-        )
-
-        Caption(text = "|")
-
-        Caption(
-            text = stringResource(
-                id = R.string.ChangePassword,
-            ),
-            onClick = {
-
-            },
-        )
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -42,7 +42,11 @@ fun LoginScreen(
         signInViewModel.signInViewEffect.collect { event ->
             when (event) {
                 Event.NavigateToHome -> {
-                    navController.navigate(route = NavigationRoute.Main)
+                    navController.navigate(NavigationRoute.Main) {
+                        popUpTo(NavigationRoute.Login) {
+                            inclusive = true
+                        }
+                    }
                 }
                 else -> {
                     toast(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -99,7 +99,23 @@ fun LoginScreen(
             ),
     ) {
 
-        MainTitle()
+        Image(
+            modifier = Modifier
+                .height(34.dp)
+                .width(97.dp),
+            painter = painterResource(id = R.drawable.ic_logo),
+            contentDescription = null,
+        )
+
+        Spacer(
+            modifier = Modifier.height(8.dp),
+        )
+
+        Body4(
+            text = stringResource(
+                id = R.string.AppDescription,
+            ),
+        )
 
         Spacer(
             modifier = Modifier.height(52.dp),
@@ -135,7 +151,7 @@ fun LoginScreen(
             onCheckedChange = onAutoLoginStateChange,
         )
 
-        AddFunction()
+        AuthOption()
 
         LoginButton(signInViewModel, scaffoldState)
     }
@@ -171,53 +187,52 @@ private fun BackPressHandle() {
 }
 
 @Composable
-fun MainTitle() {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+fun AuthOption() {
+
+    val mContext = LocalContext.current
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentWidth(CenterHorizontally)
+            .padding(
+                start = 10.dp,
+                top = 24.dp,
+                end = 10.dp,
+            ),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Image(
-            modifier = Modifier
-                .height(34.dp)
-                .width(97.dp),
-            painter = painterResource(id = R.drawable.ic_logo),
-            contentDescription = null,
+
+        Caption(
+            text = stringResource(id = R.string.DoRegister),
+            onClick = {
+                mContext.startActivity(
+                    Intent(
+                        mContext,
+                        RegisterActivity::class.java,
+                    ),
+                )
+            },
         )
-        Body4(
+
+        Caption(text = "|")
+
+        Caption(
             text = stringResource(
-                id = R.string.AppDescription,
+                id = R.string.FindId,
             ),
         )
-    }
-}
 
-@Composable
-fun AddFunction() {
-    val mContext = LocalContext.current
-    Box(
-        contentAlignment = Alignment.TopCenter,
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentWidth(CenterHorizontally)
-                .padding(
-                    start = 10.dp,
-                    top = 24.dp,
-                    end = 10.dp,
-                ),
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Caption(
-                text = stringResource(id = R.string.DoRegister),
-                onClick = {
-                    mContext.startActivity(Intent(mContext, RegisterActivity::class.java))
-                },
-            )
-            Caption(text = "|")
-            Caption(text = stringResource(id = R.string.FindId))
-            Caption(text = "|")
-            Caption(text = stringResource(id = R.string.ChangePassword))
-        }
+        Caption(text = "|")
+
+        Caption(
+            text = stringResource(
+                id = R.string.ChangePassword,
+            ),
+            onClick = {
+
+            },
+        )
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/NavigationRoute.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/NavigationRoute.kt
@@ -9,9 +9,11 @@ object NavigationRoute {
         const val MyPage = "mypage"
     }
 
+    const val ChangePassword = "changePassword"
     const val Login = "login"
     const val Main = "main"
     const val NoticeDetail = "noticeDetail/{noticeId}"
     const val PointList = "pointList"
     const val StudyRoom = "studyRoom"
+    const val StudyRoomDetail = "studyRoomDetail/{seatId}"
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
@@ -29,7 +29,9 @@ fun RootDms(
     ) {
 
         composable(NavigationRoute.Login) {
-            LoginScreen(scaffoldState = scaffoldState, navController = navController)
+            LoginScreen(
+                navController = navController,
+            )
         }
 
         composable(NavigationRoute.Main) {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import team.aliens.dms_android.feature.auth.changepassword.ChangePasswordScreen
 import team.aliens.dms_android.feature.auth.login.LoginScreen
 import team.aliens.dms_android.feature.notice.NoticeDetailScreen
 import team.aliens.dms_android.feature.pointlist.PointListScreen
@@ -17,41 +18,60 @@ import team.aliens.dms_android.feature.studyroom.StudyRoomListScreen
 fun RootDms(
     route: String,
 ) {
+
     val navController = rememberNavController()
+
     val scaffoldState = rememberScaffoldState()
 
-    NavHost(navController = navController, startDestination = route) {
-        composable(route = NavigationRoute.Login) {
+    NavHost(
+        navController = navController,
+        startDestination = route,
+    ) {
+
+        composable(NavigationRoute.Login) {
             LoginScreen(scaffoldState = scaffoldState, navController = navController)
         }
+
         composable(NavigationRoute.Main) {
             DmsApp(navController = navController, scaffoldState = scaffoldState)
         }
-        composable(route = "noticeDetail/{noticeId}",
-            arguments = listOf(navArgument("noticeId") { type = NavType.StringType })) {
+
+        composable(
+            route = NavigationRoute.NoticeDetail,
+            arguments = listOf(
+                navArgument("noticeId") { type = NavType.StringType },
+            ),
+        ) {
             val noticeId = it.arguments!!.getString("noticeId")
             if (noticeId != null) {
                 NoticeDetailScreen(navController, noticeId)
             }
         }
+
         composable(NavigationRoute.PointList) {
             PointListScreen(
                 navController = navController,
             )
         }
-        composable(route = "studyRoomDetail/{seatId}",
+
+        composable(NavigationRoute.ChangePassword) {
+            ChangePasswordScreen()
+        }
+
+        composable(
+            route = NavigationRoute.StudyRoomDetail,
             arguments = listOf(
                 navArgument("seatId") { type = NavType.StringType },
-            )) {
+            ),
+        ) {
             val roomId = it.arguments!!.getString("seatId")
             if (roomId != null) {
                 StudyRoomDetailScreen(navController = navController, roomId)
             }
         }
-        composable(NavigationRoute.StudyRoom){
-            StudyRoomListScreen(
-                navController = navController
-            )
+
+        composable(NavigationRoute.StudyRoom) {
+            StudyRoomListScreen(navController = navController)
         }
     }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/splash/Splash.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/splash/Splash.kt
@@ -3,7 +3,9 @@ package team.aliens.dms_android.feature.splash
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -11,62 +13,63 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
-import team.aliens.design_system.color.DormColor
-import team.aliens.design_system.typography.SubTitle1
 import team.aliens.dms_android.feature.MainActivity
 import team.aliens.presentation.R
 
-@Composable
-fun Splash() {
-    val viewModel: SplashViewModel = hiltViewModel()
-    viewModel.autoLogin()
-    Splash(viewModel)
-}
-
-
+// todo 스플래시 스크린을 없애는 방법 검토 필요!@!
 @Composable
 fun Splash(
-    splashViewModel: SplashViewModel,
+    splashViewModel: SplashViewModel = hiltViewModel(),
 ) {
+
+    splashViewModel.autoLogin()
+
     val coroutineScope = rememberCoroutineScope()
+
     val context = LocalContext.current
+
     LaunchedEffect(Unit) {
         coroutineScope.launch {
             splashViewModel.eventFlow.collect {
-                when (it) {
-                    SplashViewModel.Event.AutoLoginSuccess -> {
-                        startMainActivity(context, "main")
+                moveToMainActivity(
+                    context,
+                    when (it) {
+                        SplashViewModel.Event.AutoLoginSuccess -> {
+                            "main"
+                        }
+                        SplashViewModel.Event.NeedLogin -> {
+                            "login"
+                        }
                     }
-                    SplashViewModel.Event.NeedLogin -> startMainActivity(context, "login")
-                }
-            }
-        }
-    }
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Box(contentAlignment = Alignment.TopCenter) {
-            Image(
-                modifier = Modifier.size(180.dp),
-                painter = painterResource(id = R.drawable.ic_logo),
-                contentDescription = null,
-            )
-            Column {
-                Spacer(Modifier.size(142.dp))
-                SubTitle1(
-                    text = stringResource(id = R.string.Dms),
-                    color = DormColor.Gray100,
                 )
             }
         }
     }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            modifier = Modifier.size(180.dp),
+            painter = painterResource(id = R.drawable.ic_logo),
+            contentDescription = null,
+        )
+    }
 }
 
-fun startMainActivity(context: Context, route: String) {
-    val intent = Intent(context, MainActivity::class.java).apply {
-        putExtra("route", route)
-    }
+private fun moveToMainActivity(context: Context, route: String) {
+
+    val intent = Intent(
+        context,
+        MainActivity::class.java,
+    )
+
+    intent.putExtra("route", route)
+
     context.startActivity(intent)
+    (context as SplashActivity).finish()
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashActivity.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashActivity.kt
@@ -12,7 +12,7 @@ class SplashActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Splash()
+            SplashScreen()
         }
     }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashScreen.kt
@@ -21,7 +21,7 @@ import team.aliens.presentation.R
 
 // todo 스플래시 스크린을 없애는 방법 검토 필요!@!
 @Composable
-fun Splash(
+fun SplashScreen(
     splashViewModel: SplashViewModel = hiltViewModel(),
 ) {
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/splash/SplashScreen.kt
@@ -61,7 +61,10 @@ fun SplashScreen(
     }
 }
 
-private fun moveToMainActivity(context: Context, route: String) {
+private fun moveToMainActivity(
+    context: Context,
+    route: String,
+) {
 
     val intent = Intent(
         context,

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="Password">비밀번호</string>
     <string name="AutoLogin">자동로그인</string>
     <string name="DoRegister">회원가입하기</string>
-    <string name="FindId">아이디 찾운</string>
+    <string name="FindId">아이디 찾기</string>
 
     // 회원가입
     <string name="SignUpConflict">이미 회원가입 된 학생입니다</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     // 전역
     <string name="Next">다음</string>
     <string name="Check">확인</string>
-    <string name="AppDescription">더 편한 기숙사 생활을 위디</string>
+    <string name="AppDescription">더 편한 기숙사 생활을 위해</string>
 
     // 에러 처리
     <string name="Forbidden">접근 권한이 없습니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     // 로그인
     <string name="Login">로그인</string>
+    <string name="ID">아이디</string>
     <string name="Password">비밀번호</string>
     <string name="AutoLogin">자동로그인</string>
     <string name="DoRegister">회원가입하기</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="AutoLogin">자동로그인</string>
     <string name="DoRegister">회원가입하기</string>
     <string name="FindId">아이디 찾기</string>
+    <string name="PleaseEnterId">아이디를 입력해 주세요</string>
+    <string name="PleaseEnterPassword">비밀번호를 입력해 주세요</string>
 
     // 회원가입
     <string name="SignUpConflict">이미 회원가입 된 학생입니다</string>


### PR DESCRIPTION
## 개요
> 로그인 화면, 메인 화면 등에서 뒤로가기 버튼을 눌러 즉시 앱이 종료되어야 할 상황에, 앱이 종료되지 않은 채 이전 스크린이 남아있는 버그를 수정합니다.

## 작업사항
- 스플래시 화면이 backStack에 남아있는 문제를 수정하였습니다
- Login 화면이 Main 화면에서 뒤로가기 버튼을 눌렀을 때 유지되는 문제를 수정하였습니다
- 비밀번호 변경 텍스트를 눌렀을 때, 해당 스크린으로 이동하는 로직을 구현하였습니다
- LoginScreen을 리팩토링 하였습니다
  - Composable 함수 다중 호출로 인한 복잡한 상태 관리를 최적화하기 위해, 기존의 뷰를 각기 다른 composable 함수에서 뷰를 구성하였던 로직을 평탄화?(flatten) 하였습니다

## 추가 로 할 말
