### PR TITLE
🔀 :: (#230) edit top padding of application screen and notice screen

### DIFF
--- a/design-system/src/main/java/team/aliens/design_system/component/notice.kt
+++ b/design-system/src/main/java/team/aliens/design_system/component/notice.kt
@@ -34,7 +34,6 @@ fun NoticeList(
         itemsIndexed(items = notices) { index, notice ->
             Notice(
                 notice = notice,
-                index = index,
                 onClick = onClick,
             )
 
@@ -48,14 +47,13 @@ fun NoticeList(
 @Composable
 private fun Notice(
     notice: Notice,
-    index: Int,
     onClick: (String) -> Unit,
 ) {
     Box(
         modifier = Modifier.background(
             color = DormColor.Gray100,
             shape = RoundedCornerShape(6.dp),
-        ).fillMaxWidth().height(70.dp).dormShadow(
+        ).fillMaxWidth().dormShadow(
             color = DormColor.Gray100,
             offsetX = 1.dp,
             offsetY = 1.dp,
@@ -70,6 +68,7 @@ private fun Notice(
             Modifier.padding(horizontal = 16.dp),
         ) {
             Body4(
+                modifier = Modifier.padding(top = 12.dp),
                 text = notice.title,
                 color = DormColor.Gray900,
             )
@@ -77,6 +76,7 @@ private fun Notice(
             Spacer(modifier = Modifier.height(4.dp))
 
             OverLine(
+                modifier = Modifier.padding(bottom = 12.dp),
                 text = notice.createAt,
                 color = DormColor.Gray500,
             )

--- a/design-system/src/main/java/team/aliens/design_system/component/notice.kt
+++ b/design-system/src/main/java/team/aliens/design_system/component/notice.kt
@@ -1,6 +1,7 @@
 package team.aliens.design_system.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -8,6 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import team.aliens.design_system.color.DormColor
@@ -50,18 +52,20 @@ private fun Notice(
     onClick: (String) -> Unit,
 ) {
     Box(
-        modifier = Modifier.background(
-            color = DormColor.Gray100,
-            shape = RoundedCornerShape(6.dp),
-        ).fillMaxWidth().dormShadow(
-            color = DormColor.Gray100,
-            offsetX = 1.dp,
-            offsetY = 1.dp,
-        ).dormClickable(
-            rippleEnabled = true,
-        ) {
-            onClick(notice.noticeId)
-        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape = RoundedCornerShape(6.dp))
+            .background(
+                color = DormColor.Gray100,
+            )
+            .dormClickable{
+                onClick(notice.noticeId)
+            }
+            .dormShadow(
+                color = DormColor.Gray100,
+                offsetX = 1.dp,
+                offsetY = 1.dp,
+            ),
         contentAlignment = Alignment.CenterStart,
     ) {
         Column(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/notice/NoticeScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/notice/NoticeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -135,10 +136,20 @@ fun NoticeOrderButton(
         mutableStateOf("최신순")
     }
     Button(
+        modifier = Modifier
+            .border(
+                color = DormColor.Gray600,
+                width = 1.dp,
+                shape = RoundedCornerShape(15),
+            )
+            .size(
+                width = 94.dp,
+                height = 40.dp,
+            ),
         onClick = {
             if (noticeViewModel.state.value.type == NoticeListSCType.NEW) {
                 noticeViewModel.state.value.type = NoticeListSCType.OLD
-                text = "오래된순"
+                text = "오래된 순"
                 noticeViewModel.fetchNoticeList()
             } else {
                 noticeViewModel.state.value.type = NoticeListSCType.NEW
@@ -147,10 +158,6 @@ fun NoticeOrderButton(
             }
         },
         colors = ButtonDefaults.buttonColors(backgroundColor = DormColor.Gray100),
-        modifier = Modifier
-            .padding(start = 20.dp)
-            .border(color = DormColor.Gray600, width = 1.dp, shape = RoundedCornerShape(15))
-            .size(width = 88.dp, height = 40.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxSize(),

--- a/presentation/src/main/java/team/aliens/dms_android/feature/notice/NoticeScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/notice/NoticeScreen.kt
@@ -102,33 +102,28 @@ fun NoticeScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(DormColor.Gray200),
+            .background(DormColor.Gray200)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        NoticeTopBar()
-        NoticeOrderButton(noticeViewModel)
+        Spacer(modifier = Modifier.height(14.dp))
+        Body1(text = stringResource(id = R.string.Notice))
+        Spacer(modifier = Modifier.height(20.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start,
+        ) {
+            NoticeOrderButton(noticeViewModel)
+        }
         NoticeList(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 20.dp, start = 20.dp, end = 20.dp),
+                .padding(top = 20.dp),
             notices = notices,
             onClick = { noticeId ->
                 navController.navigate("noticeDetail/${noticeId}")
             },
         )
-    }
-}
-
-@Composable
-fun NoticeTopBar() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(85.dp)
-            .padding(horizontal = 25.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        Body1(text = stringResource(id = R.string.Notice))
     }
 }
 


### PR DESCRIPTION
## 개요
> notice screen 과 application screen 상단 text padding 을 통일했습니다

## 작업사항
- 상단 text padding 통일
- notice screen 최신순 버튼 크기 수정
- notice item 클릭 시 ripple shape 수정
- 공지 목록에서 제목이 2줄 이상일시 padding 조절

## 추가 로 할 말
Closes #230 