### PR TITLE
🔀 :: (#227) refactor ExamineSchoolCode, ConfirmSchool 

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/event/school/ConfirmSchoolEvent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/event/school/ConfirmSchoolEvent.kt
@@ -1,22 +1,14 @@
 package team.aliens.dms_android.feature.register.event.school
 
-import team.aliens.dms_android.base.MviEvent
 import team.aliens.domain.entity.user.SchoolConfirmQuestionEntity
 
-sealed class ConfirmSchoolEvent : MviEvent {
+sealed interface ConfirmSchoolEvent
     data class FetchSchoolQuestion(val schoolConfirmQuestionEntity: SchoolConfirmQuestionEntity) :
-        ConfirmSchoolEvent()
+        ConfirmSchoolEvent
 
-    object CompareSchoolAnswerSuccess : ConfirmSchoolEvent()
-    object CompareSchoolBadRequestException : ConfirmSchoolEvent()
-    object CompareSchoolUnauthorizedException : ConfirmSchoolEvent()
-    object CompareSchoolNotFoundException : ConfirmSchoolEvent()
-    object CompareSchoolTooManyRequestException : ConfirmSchoolEvent()
-    object CompareSchoolInternalServerException : ConfirmSchoolEvent()
-    object SchoolQuestionBadRequestException : ConfirmSchoolEvent()
-    object SchoolQuestionNotFoundException : ConfirmSchoolEvent()
-    object SchoolQuestionTooManyRequestException : ConfirmSchoolEvent()
-    object SchoolQuestionInternalServerException : ConfirmSchoolEvent()
-    object UnknownException : ConfirmSchoolEvent()
-}
+    object CompareSchoolAnswerSuccess : ConfirmSchoolEvent
+
+    object NotFoundCompareSchool : ConfirmSchoolEvent
+
+    object MissMatchCompareSchool : ConfirmSchoolEvent
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/event/school/ExamineSchoolCodeEvent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/event/school/ExamineSchoolCodeEvent.kt
@@ -1,12 +1,6 @@
 package team.aliens.dms_android.feature.register.event.school
 
-import team.aliens.dms_android.base.MviEvent
+sealed interface ExamineSchoolCodeEvent
 
-sealed class ExamineSchoolCodeEvent : MviEvent {
-    object ExamineSchoolCodeSuccess : ExamineSchoolCodeEvent()
-    object BadRequestException : ExamineSchoolCodeEvent()
-    object UnAuthorizedException : ExamineSchoolCodeEvent()
-    object TooManyRequestException : ExamineSchoolCodeEvent()
-    object InternalServerException : ExamineSchoolCodeEvent()
-    object UnknownException : ExamineSchoolCodeEvent()
-}
+object ExamineSchoolCodeSuccess : ExamineSchoolCodeEvent
+object MissMatchSchoolCode : ExamineSchoolCodeEvent

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EnterEmailFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/EnterEmailFragment.kt
@@ -6,11 +6,11 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.util.emailValidation
-import team.aliens.dms_android.util.visible
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentEnterEmailBinding
 import java.util.regex.Pattern
@@ -82,7 +82,7 @@ class EnterEmailFragment : BaseFragment<FragmentEnterEmailBinding>(R.layout.frag
             registerActive.supportFragmentManager.beginTransaction()
                 .replace(R.id.containerRegister, fragment).addToBackStack("EnterEmail").commit()
         } else {
-            binding.tvError.visible()
+            binding.tvError.isVisible = true
             binding.btnSendCode.isClickable = false
             binding.btnSendCode.isEnabled = false
             binding.btnSendCode.setBackgroundResource(R.drawable.register_custom_btn_background)

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/id/SetIdFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/id/SetIdFragment.kt
@@ -6,6 +6,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
@@ -13,7 +14,6 @@ import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.event.id.SetIdEvent
 import team.aliens.dms_android.feature.register.ui.password.SetPasswordFragment
 import team.aliens.dms_android.util.repeatOnStarted
-import team.aliens.dms_android.util.visible
 import team.aliens.dms_android.viewmodel.auth.register.id.SetIdViewModel
 import team.aliens.domain.entity.user.ExamineGradeEntity
 import team.aliens.presentation.R
@@ -110,7 +110,7 @@ class SetIdFragment : BaseFragment<FragmentSetIdBinding>(R.layout.fragment_set_i
 
             is SetIdEvent.DuplicateIdConflictException -> {
                 binding.etId.setBackgroundResource(R.drawable.register_et_error_background)
-                binding.tvError.visible()
+                binding.tvError.isVisible = true
             }
 
             is SetIdEvent.DuplicateIdBadRequestException -> showShortToast(getString(R.string.BadRequest))

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
@@ -114,7 +114,7 @@ class SetPasswordFragment :
             }
 
             override fun afterTextChanged(p0: Editable?) {
-                if (binding.etEnterPassword.text!!.isEmpty() && binding.etReEnterPassword.text!!.isNotEmpty()) {
+                if (binding.etEnterPassword.text!!.isNotEmpty() && binding.etReEnterPassword.text!!.isNotEmpty()) {
                     binding.btnVerificationCode.isEnabled = true
                     binding.btnVerificationCode.setBackgroundResource(R.drawable.register_custom_active_btn_background)
                 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/password/SetPasswordFragment.kt
@@ -6,11 +6,11 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.RegisterActivity
 import team.aliens.dms_android.feature.register.ui.last.SetProfileImageFragment
-import team.aliens.dms_android.util.visible
 import team.aliens.presentation.R
 import team.aliens.presentation.databinding.FragmentSetPasswordBinding
 
@@ -81,7 +81,7 @@ class SetPasswordFragment :
                     .commit()
             } else {
                 binding.etReEnterPassword.setBackgroundResource(R.drawable.register_et_error_background)
-                binding.tvError.visible()
+                binding.tvError.isVisible = true
                 binding.btnVerificationCode.setBackgroundResource(R.drawable.register_custom_btn_background)
                 binding.btnVerificationCode.isEnabled = false
             }
@@ -114,7 +114,7 @@ class SetPasswordFragment :
             }
 
             override fun afterTextChanged(p0: Editable?) {
-                if (binding.etEnterPassword.text!!.isNotEmpty() && binding.etReEnterPassword.text!!.isNotEmpty()) {
+                if (binding.etEnterPassword.text!!.isEmpty() && binding.etReEnterPassword.text!!.isNotEmpty()) {
                     binding.btnVerificationCode.isEnabled = true
                     binding.btnVerificationCode.setBackgroundResource(R.drawable.register_custom_active_btn_background)
                 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
@@ -2,22 +2,20 @@ package team.aliens.dms_android.feature.register.ui.school
 
 import android.content.Intent
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import team.aliens.dms_android.base.BaseFragment
 import team.aliens.dms_android.feature.MainActivity
 import team.aliens.dms_android.feature.RegisterActivity
-import team.aliens.dms_android.feature.register.event.school.ConfirmSchoolEvent
+import team.aliens.dms_android.feature.register.event.school.*
 import team.aliens.dms_android.feature.register.ui.email.EnterEmailFragment
-import team.aliens.dms_android.util.invisible
-import team.aliens.dms_android.util.repeatOnStarted
-import team.aliens.dms_android.util.visible
+import team.aliens.dms_android.util.repeatOnFragmentStarted
 import team.aliens.dms_android.viewmodel.auth.register.school.ConfirmSchoolViewModel
 import team.aliens.domain.entity.user.SchoolConfirmQuestionEntity
 import team.aliens.presentation.R
@@ -42,10 +40,10 @@ class ConfirmSchoolFragment :
         inputData = args?.get("schoolId") as String
         schoolCode = args.get("schoolCode") as String
 
-        val uuid = UUID.fromString(inputData.toString())
+        val uuid = UUID.fromString(inputData)
         confirmSchoolViewModel.schoolId = uuid
 
-        repeatOnStarted {
+        repeatOnFragmentStarted {
             confirmSchoolViewModel.confirmSchoolEvent.collect { event -> handleEvent(event) }
         }
 
@@ -56,7 +54,9 @@ class ConfirmSchoolFragment :
 
     private fun handleEvent(event: ConfirmSchoolEvent) {
         when (event) {
-            is ConfirmSchoolEvent.CompareSchoolAnswerSuccess -> {
+            is FetchSchoolQuestion -> setSchoolQuestionValue(event.schoolConfirmQuestionEntity)
+            is CompareSchoolAnswerSuccess -> {
+                //Fixme : 추후PR에서 개선 필요
                 val registerActive = activity as RegisterActivity
 
                 val bundle = Bundle()
@@ -71,46 +71,22 @@ class ConfirmSchoolFragment :
                     .replace(R.id.containerRegister, fragment).commit()
             }
 
-            is ConfirmSchoolEvent.CompareSchoolBadRequestException -> {
-                binding.tvError.text = getString(R.string.BadRequest)
-                binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
-                    R.color.error))
-                binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
-                binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
-                binding.tvError.visible()
-            }
-
-            is ConfirmSchoolEvent.CompareSchoolNotFoundException -> {
-                binding.tvError.text = getString(R.string.CompareSchoolNotFound)
-                binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
-                    R.color.error))
-                binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
-                binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
-                binding.tvError.visible()
-            }
-
-            is ConfirmSchoolEvent.CompareSchoolUnauthorizedException -> {
+            MissMatchCompareSchool -> {
                 binding.tvError.text = getString(R.string.InconsistentSchoolReply)
                 binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
                     R.color.error))
                 binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
                 binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
-                binding.tvError.visible()
+                binding.tvError.isVisible = true
             }
-
-            is ConfirmSchoolEvent.SchoolQuestionInternalServerException -> showShortToast(getString(
-                R.string.ServerException))
-
-            is ConfirmSchoolEvent.SchoolQuestionTooManyRequestException -> showShortToast(getString(
-                R.string.TooManyRequest))
-
-            is ConfirmSchoolEvent.CompareSchoolInternalServerException -> showShortToast(getString(R.string.ServerException))
-            is ConfirmSchoolEvent.CompareSchoolTooManyRequestException -> showShortToast(getString(R.string.TooManyRequest))
-
-            is ConfirmSchoolEvent.SchoolQuestionBadRequestException -> showShortToast(getString(R.string.BadRequest))
-            is ConfirmSchoolEvent.SchoolQuestionNotFoundException -> showShortToast(getString(R.string.CompareSchoolNotFound))
-            is ConfirmSchoolEvent.FetchSchoolQuestion -> setSchoolQuestionValue(event.schoolConfirmQuestionEntity)
-            is ConfirmSchoolEvent.UnknownException -> showShortToast(getString(R.string.UnKnownException))
+            NotFoundCompareSchool -> {
+                binding.tvError.text = getString(R.string.CompareSchoolNotFound)
+                binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
+                    R.color.error))
+                binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
+                binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
+                binding.tvError.isVisible = true
+            }
         }
     }
 
@@ -123,25 +99,16 @@ class ConfirmSchoolFragment :
             startActivity(intent)
         }
 
-        binding.etReply.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-
-            }
-
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                answer = p0.toString()
-            }
-
-            override fun afterTextChanged(p0: Editable?) {
-                if (p0!!.isNotEmpty()) {
-                    binding.tvError.invisible()
-                    binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_active_btn_background)
-                    binding.etReply.setBackgroundResource(R.drawable.register_et_background)
-                    binding.btnConfirm.isClickable = true
-                    binding.btnConfirm.isEnabled = true
-                }
-            }
-        })
+       with(binding.etReply){
+           addTextChangedListener {
+               answer = it.toString()
+               binding.tvError.isVisible = false
+               binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_active_btn_background)
+               binding.etReply.setBackgroundResource(R.drawable.register_et_background)
+               binding.btnConfirm.isClickable = true
+               binding.btnConfirm.isEnabled = true
+           }
+       }
 
         binding.btnConfirm.setOnClickListener {
             confirmSchoolViewModel.compareSchoolAnswer(answer)

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/school/ConfirmSchoolFragment.kt
@@ -73,16 +73,24 @@ class ConfirmSchoolFragment :
 
             MissMatchCompareSchool -> {
                 binding.tvError.text = getString(R.string.InconsistentSchoolReply)
-                binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
-                    R.color.error))
+                binding.tvError.setTextColor(
+                    ContextCompat.getColor(
+                        requireContext(),
+                        R.color.error
+                    )
+                )
                 binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
                 binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
                 binding.tvError.isVisible = true
             }
             NotFoundCompareSchool -> {
                 binding.tvError.text = getString(R.string.CompareSchoolNotFound)
-                binding.tvError.setTextColor(ContextCompat.getColor(requireContext(),
-                    R.color.error))
+                binding.tvError.setTextColor(
+                    ContextCompat.getColor(
+                        requireContext(),
+                        R.color.error
+                    )
+                )
                 binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_btn_background)
                 binding.etReply.setBackgroundResource(R.drawable.register_et_error_background)
                 binding.tvError.isVisible = true
@@ -99,16 +107,14 @@ class ConfirmSchoolFragment :
             startActivity(intent)
         }
 
-       with(binding.etReply){
-           addTextChangedListener {
-               answer = it.toString()
-               binding.tvError.isVisible = false
-               binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_active_btn_background)
-               binding.etReply.setBackgroundResource(R.drawable.register_et_background)
-               binding.btnConfirm.isClickable = true
-               binding.btnConfirm.isEnabled = true
-           }
-       }
+        binding.etReply.addTextChangedListener {
+            answer = it.toString()
+            binding.tvError.isVisible = false
+            binding.btnConfirm.setBackgroundResource(R.drawable.register_custom_active_btn_background)
+            binding.etReply.setBackgroundResource(R.drawable.register_et_background)
+            binding.btnConfirm.isClickable = true
+            binding.btnConfirm.isEnabled = true
+        }
 
         binding.btnConfirm.setOnClickListener {
             confirmSchoolViewModel.compareSchoolAnswer(answer)

--- a/presentation/src/main/java/team/aliens/dms_android/util/LifeCycle.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/util/LifeCycle.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms_android.util
 
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -11,4 +12,8 @@ fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
     lifecycleScope.launch {
         lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
     }
+}
+
+fun Fragment.repeatOnFragmentStarted(block: suspend CoroutineScope.() -> Unit) {
+    viewLifecycleOwner.repeatOnStarted(block)
 }

--- a/presentation/src/main/java/team/aliens/dms_android/util/View.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/util/View.kt
@@ -1,16 +1,11 @@
 package team.aliens.dms_android.util
 
-import android.view.View
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import team.aliens.dms_android.feature.RegisterActivity
+import team.aliens.presentation.R
 
-fun View.isVisible() = this.visibility == View.VISIBLE
-
-fun View.visible() {
-    this.visibility = View.VISIBLE
-}
-
-fun View.invisible() {
-    this.visibility = View.GONE
-}
 
 const val emailValidation =
     "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/school/ConfirmSchoolViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/school/ConfirmSchoolViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import team.aliens.dms_android.feature.register.event.school.ConfirmSchoolEvent
+import team.aliens.dms_android.feature.register.event.school.*
 import team.aliens.dms_android.util.MutableEventFlow
 import team.aliens.dms_android.util.asEventFlow
 import team.aliens.domain.entity.user.SchoolConfirmQuestionEntity
@@ -29,18 +29,18 @@ class ConfirmSchoolViewModel @Inject constructor(
     fun compareSchoolAnswer(answer: String) {
         viewModelScope.launch {
             kotlin.runCatching {
-                remoteSchoolAnswerUseCase.execute(SchoolAnswerParam(schoolId = schoolId,
-                    answer = answer))
+                remoteSchoolAnswerUseCase.execute(
+                    SchoolAnswerParam(
+                        schoolId = schoolId,
+                        answer = answer
+                    )
+                )
             }.onSuccess {
-                event(ConfirmSchoolEvent.CompareSchoolAnswerSuccess)
+                event(CompareSchoolAnswerSuccess)
             }.onFailure {
                 when (it) {
-                    is BadRequestException -> event(ConfirmSchoolEvent.CompareSchoolBadRequestException)
-                    is UnauthorizedException -> event(ConfirmSchoolEvent.CompareSchoolUnauthorizedException)
-                    is NotFoundException -> event(ConfirmSchoolEvent.CompareSchoolNotFoundException)
-                    is TooManyRequestException -> event(ConfirmSchoolEvent.CompareSchoolTooManyRequestException)
-                    is ServerException -> event(ConfirmSchoolEvent.CompareSchoolInternalServerException)
-                    else -> event(ConfirmSchoolEvent.UnknownException)
+                    is UnauthorizedException -> event(MissMatchCompareSchool)
+                    is NotFoundException -> event(NotFoundCompareSchool)
                 }
             }
         }
@@ -49,18 +49,8 @@ class ConfirmSchoolViewModel @Inject constructor(
 
     fun schoolQuestion(schoolId: UUID) {
         viewModelScope.launch {
-            kotlin.runCatching {
-                remoteSchoolQuestionUseCase.execute(schoolId).collect {
-                    event(ConfirmSchoolEvent.FetchSchoolQuestion(it.toData()))
-                }
-            }.onFailure {
-                when (it) {
-                    is BadRequestException -> event(ConfirmSchoolEvent.SchoolQuestionBadRequestException)
-                    is NotFoundException -> event(ConfirmSchoolEvent.SchoolQuestionNotFoundException)
-                    is TooManyRequestException -> event(ConfirmSchoolEvent.SchoolQuestionTooManyRequestException)
-                    is ServerException -> event(ConfirmSchoolEvent.SchoolQuestionInternalServerException)
-                    else -> event(ConfirmSchoolEvent.UnknownException)
-                }
+            remoteSchoolQuestionUseCase.execute(schoolId).collect {
+                event(FetchSchoolQuestion(it.toData()))
             }
         }
     }

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/school/ExamineSchoolCodeViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/school/ExamineSchoolCodeViewModel.kt
@@ -5,11 +5,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import team.aliens.dms_android.feature.register.event.school.ExamineSchoolCodeEvent
+import team.aliens.dms_android.feature.register.event.school.ExamineSchoolCodeSuccess
+import team.aliens.dms_android.feature.register.event.school.MissMatchSchoolCode
 import team.aliens.dms_android.util.MutableEventFlow
 import team.aliens.dms_android.util.asEventFlow
-import team.aliens.domain.exception.BadRequestException
-import team.aliens.domain.exception.ServerException
-import team.aliens.domain.exception.TooManyRequestException
 import team.aliens.domain.exception.UnauthorizedException
 import team.aliens.domain.usecase.schools.RemoteSchoolCodeUseCase
 import java.util.*
@@ -25,20 +24,14 @@ class ExamineSchoolCodeViewModel @Inject constructor(
 
     var schoolId: UUID = UUID(0, 0)
 
-    fun examineSchoolCode(schoolCode: String) {
+    internal fun examineSchoolCode(schoolCode: String) {
         viewModelScope.launch {
             kotlin.runCatching {
                 schoolId = remoteSchoolCodeUseCase.execute(schoolCode).schoolId
             }.onSuccess {
-                event(ExamineSchoolCodeEvent.ExamineSchoolCodeSuccess)
+                event(ExamineSchoolCodeSuccess)
             }.onFailure {
-                when (it) {
-                    is BadRequestException -> event(ExamineSchoolCodeEvent.BadRequestException)
-                    is UnauthorizedException -> event(ExamineSchoolCodeEvent.UnAuthorizedException)
-                    is TooManyRequestException -> event(ExamineSchoolCodeEvent.TooManyRequestException)
-                    is ServerException -> event(ExamineSchoolCodeEvent.InternalServerException)
-                    else -> event(ExamineSchoolCodeEvent.UnknownException)
-                }
+                if (it is UnauthorizedException) event(MissMatchSchoolCode)
             }
         }
     }


### PR DESCRIPTION
## 개요
> 학교 인증 코드, 학교 확인 질문 코드를 리팩토링했습니다.

## 작업사항
- LifeCycle.kt : Fragment를 위한 repeatOnStarted 함수를 만들어주었습니다.
- View.kt : Visible 로직 제거 (isVisible로 대체 가능)
- ExamineSchoolCodeEvent.kt : 필요없는 이벤트 제거 및 네이밍 변경
- ExamineSchoolCodeViewModel.kt : 바뀐 이벤트에 따라 이벤트 처리 수정
- SchoolCertificationFragment.kt : collect 처리 로직 수정
- ConfirmSchoolEvent.kt : 필요없는 이벤트 제거 및 네이밍 변경
- ConfirmSchoolViewModel.kt : 바뀐 이벤트에 따라 이벤트 처리 수정
- ConfirmSchoolFragment.kt : TextWacher 로직 개선 및 로직 수정
- EnterEmailFragment.kt, SetIdFragment.kt, SetPasswordFragment.kt : visible로직 제거함으로 인해 isVisible로 대체

## 추가로 할 말
추후에 Fragment 이동 로직, 값 넘기는 로직만 따로 PR파서 수정할 예정입니다.
많이 마음에 안 들고 안 좋은 코드들이 많지만
시간이 많지 않아 간단히 수정하는 정도만 진행했습니다. 