### PR TITLE
🔀 :: (#249) implement verify current password screen

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/component/AppLogo.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/component/AppLogo.kt
@@ -1,0 +1,26 @@
+package team.aliens.dms_android.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import team.aliens.presentation.R
+
+@Composable
+fun AppLogo() {
+    Box(
+        modifier = Modifier
+            .size(
+                width = 96.dp,
+                height = 34.dp,
+            )
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_logo),
+            contentDescription = null,
+        )
+    }
+}

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/changepassword/SuccessChangePasswordScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/changepassword/SuccessChangePasswordScreen.kt
@@ -1,0 +1,54 @@
+package team.aliens.dms_android.feature.auth.changepassword
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import team.aliens.design_system.button.DormButtonColor
+import team.aliens.design_system.button.DormContainedLargeButton
+import team.aliens.design_system.color.DormColor
+import team.aliens.design_system.typography.Body2
+import team.aliens.dms_android.util.TopBar
+import team.aliens.presentation.R
+
+@Composable
+fun SuccessChangePasswordScreen(
+    navController: NavController,
+) {
+    Column(
+        modifier = Modifier.background(color = DormColor.Gray200)
+    ) {
+        TopBar(title = stringResource(id = R.string.ChangePassword)) {
+            navController.popBackStack()
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = 16.dp,
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(200.dp))
+            Image(
+                painter = painterResource(id = R.drawable.ic_success_change_password),
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            Body2(text = stringResource(id = R.string.SuccessChangePassword))
+            Spacer(modifier = Modifier.fillMaxHeight(0.8f))
+            DormContainedLargeButton(
+                text = stringResource(id = R.string.Check),
+                color = DormButtonColor.Blue,
+            ) {
+                // TODO implement onclick event
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/comparepassword/ComparePasswordScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/comparepassword/ComparePasswordScreen.kt
@@ -1,0 +1,79 @@
+package team.aliens.dms_android.feature.auth.comparepassword
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import team.aliens.design_system.button.DormButtonColor
+import team.aliens.design_system.button.DormContainedLargeButton
+import team.aliens.design_system.textfield.DormTextField
+import team.aliens.design_system.typography.Body2
+import team.aliens.dms_android.component.AppLogo
+import team.aliens.dms_android.util.TopBar
+import team.aliens.dms_android.viewmodel.changepw.ChangePasswordViewModel
+import team.aliens.presentation.R
+
+@Composable
+fun ComparePasswordScreen(
+    navController: NavController,
+    changePasswordViewModel: ChangePasswordViewModel = hiltViewModel(),
+) {
+
+    var password by remember { mutableStateOf("")}
+
+    val onPasswordChange = { value: String ->
+        password = value
+        // TODO 뷰모델 함수 호출해주기
+    }
+
+    LaunchedEffect(Unit){
+        // TODO 뷰모델 event collect 해주기
+    }
+
+    Column {
+        TopBar(title = stringResource(id = R.string.ChangePassword)){
+            navController.popBackStack()
+        }
+        Column(
+            modifier = Modifier.padding(
+                top = 50.dp,
+                start = 16.dp,
+                end = 16.dp,
+            )
+        ){
+            AppLogo()
+            Spacer(modifier = Modifier.height(32.dp))
+            Body2(text = stringResource(id = R.string.OriginPw))
+            Spacer(modifier = Modifier.height(100.dp))
+            DormTextField(
+                value = password,
+                onValueChange = onPasswordChange,
+                isPassword = true,
+                hint = stringResource(id = R.string.Password),
+                errorDescription = stringResource(id = R.string.CheckPassword),
+                // TODO 에러 처리 해주기
+            )
+            Spacer(modifier = Modifier.fillMaxHeight(0.8f))
+            DormContainedLargeButton(
+                text = stringResource(id = R.string.Next),
+                color = DormButtonColor.Blue,
+                enabled = password.isNotEmpty(),
+            ){
+                // TODO 뷰모델 함수 호출해주기
+            }
+        }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun Preview() {
+    ComparePasswordScreen(navController = rememberNavController())
+}

--- a/presentation/src/main/java/team/aliens/dms_android/feature/remain/RemainApplicationScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/remain/RemainApplicationScreen.kt
@@ -292,7 +292,7 @@ private fun getStringFromEvent(
         when (event) {
             is Event.BadRequestException -> R.string.BadRequest
             is Event.UnauthorizedException -> R.string.UnAuthorized
-            is Event.ForbiddenException -> R.string.Forbidden
+            is Event.ForbiddenException -> R.string.ForbiddenApplyRemain
             is Event.TooManyRequestException -> R.string.TooManyRequest
             is Event.ServerException -> R.string.ServerException
             else -> R.string.UnKnownException

--- a/presentation/src/main/java/team/aliens/dms_android/feature/remain/RemainApplicationScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/remain/RemainApplicationScreen.kt
@@ -81,6 +81,7 @@ fun RemainApplicationScreen(
                     is Event.RemainOptions -> {
                         remainOptions.addAll(it.remainOptionsEntity.remainOptionEntities)
                     }
+                    is Event.NotFoundException -> {}
                     else -> {
                         toast(
                             getStringFromEvent(

--- a/presentation/src/main/java/team/aliens/dms_android/util/TopBar.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/util/TopBar.kt
@@ -47,6 +47,6 @@ fun TopBar(
             contentDescription = stringResource(id = R.string.BackButton),
         )
         Spacer(modifier = Modifier.width(32.dp))
-        Body3(text = title)
+        Body1(text = title)
     }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/remain/RemainApplicationViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/remain/RemainApplicationViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import team.aliens.dms_android.base.BaseViewModel
-import team.aliens.dms_android.viewmodel.remain.RemainApplicationViewModel.Event
 import team.aliens.dms_android.feature.remain.RemainApplicationEvent
 import team.aliens.dms_android.feature.remain.RemainApplicationState
 import team.aliens.dms_android.util.MutableEventFlow
 import team.aliens.dms_android.util.asEventFlow
+import team.aliens.dms_android.viewmodel.remain.RemainApplicationViewModel.Event
 import team.aliens.domain.entity.remain.AvailableRemainTimeEntity
 import team.aliens.domain.entity.remain.RemainOptionsEntity
 import team.aliens.domain.exception.*
@@ -110,6 +110,7 @@ class RemainApplicationViewModel @Inject constructor(
         data class RemainOptions(val remainOptionsEntity: RemainOptionsEntity) : Event()
 
         object BadRequestException : Event()
+        object NotFoundException: Event()
         object UnauthorizedException : Event()
         object ForbiddenException : Event()
         object TooManyRequestException : Event()
@@ -125,6 +126,7 @@ private fun getEventFromThrowable(
 ): Event {
     return when(throwable){
         is BadRequestException -> Event.BadRequestException
+        is NotFoundException -> Event.NotFoundException
         is UnauthorizedException -> Event.UnauthorizedException
         is ForbiddenException -> Event.ForbiddenException
         is TooManyRequestException -> Event.TooManyRequestException

--- a/presentation/src/main/res/drawable/ic_success_change_password.xml
+++ b/presentation/src/main/res/drawable/ic_success_change_password.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="80dp"
+    android:height="80dp"
+    android:viewportWidth="80"
+    android:viewportHeight="80">
+  <group>
+    <clip-path
+        android:pathData="M0,0h80v80h-80z"/>
+    <path
+        android:pathData="M39.999,73.334C21.589,73.334 6.666,58.41 6.666,40C6.666,21.59 21.589,6.667 39.999,6.667C58.409,6.667 73.333,21.59 73.333,40C73.333,58.41 58.409,73.334 39.999,73.334ZM36.676,53.334L60.243,29.764L55.529,25.05L36.676,43.907L27.246,34.477L22.533,39.19L36.676,53.334Z"
+        android:fillColor="#3D8AFF"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="ChangePassword">비밀번호 변경</string>
     <string name="PwWarning">비밀번호는 영문, 숫자, 기호를 포함한 8~20자이어야 합니다.</string>
     <string name="OriginPw">기존 비밀번호</string>
+    <string name="SuccessChangePassword">비밀번호가 변경되었습니다.</string>
 
     // 급식
     <string name="TodayCafeteria">오늘의 급식</string>


### PR DESCRIPTION
## 개요
> 현재 비밀번호 인증 화면과 비밀번호 변경 성공 화면을 퍼블리싱 했습니다.

## 작업사항
- ComparePasswordScreen 퍼블리싱
- SuccessChangePasswordScreen 퍼블리싱
- Dms Logo 컴포넌트 생성
- 잔류 신청 화면에서 "알 수 없음" 오류가 뜨는 버그를 수정했습니다.

## 추가 로 할 말
- 비즈니스 로직은 아직 구현하지 않아서 비밀번호 변경 로직 머지 후 통합하여 리팩토링 및 비즈니스 로직 작성할 계획입니다