### PR TITLE
🔀 :: (#280) implement dialog dismissing when background pressed

### DIFF
--- a/design-system/src/main/java/team/aliens/design_system/dialog/dialog.kt
+++ b/design-system/src/main/java/team/aliens/design_system/dialog/dialog.kt
@@ -24,6 +24,7 @@ import team.aliens.design_system.button.DormButtonColor
 import team.aliens.design_system.button.DormContainedLargeButton
 import team.aliens.design_system.color.DormColor
 import team.aliens.design_system.icon.DormIcon
+import team.aliens.design_system.modifier.dormClickable
 import team.aliens.design_system.typography.Body2
 import team.aliens.design_system.typography.Body3
 import team.aliens.design_system.typography.Body5
@@ -171,10 +172,15 @@ fun DormBottomAlignedSingleButtonDialog(
     btnText: String,
     onBtnClick: () -> Unit,
     btnTextColor: Color = DormColor.Gray600,
+    onBackgroundPress: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .dormClickable {
+                onBackgroundPress()
+            },
         contentAlignment = Alignment.BottomCenter,
     ) {
         Column(
@@ -332,6 +338,9 @@ fun PreviewDialog() {
             DormBottomAlignedSingleButtonDialog(
                 btnText = "취소",
                 onBtnClick = { },
+                onBackgroundPress = {
+
+                }
             ) {
 
             }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/image/ConfirmImageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/image/ConfirmImageScreen.kt
@@ -83,6 +83,10 @@ internal fun ConfirmImageScreen(
         mutableStateOf(false)
     }
 
+    val onDialogDismiss = {
+        gettingImageOptionDialogState = false
+    }
+
     if (gettingImageOptionDialogState) {
         GettingImageOptionDialog(
             onCancel = {
@@ -101,6 +105,7 @@ internal fun ConfirmImageScreen(
                     gettingImageOptionDialogState = false
                 }
             },
+            onDialogDismiss = onDialogDismiss,
         )
     }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/image/GettingImageOptionDialog.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/image/GettingImageOptionDialog.kt
@@ -22,6 +22,7 @@ internal fun GettingImageOptionDialog(
     onCancel: () -> Unit,
     onTakePhoto: () -> Unit,
     onSelectPhoto: () -> Unit,
+    onDialogDismiss: () -> Unit,
 ) {
 
     val toast = rememberToast()
@@ -37,6 +38,7 @@ internal fun GettingImageOptionDialog(
         DormBottomAlignedSingleButtonDialog(
             btnText = stringResource(R.string.Cancel),
             onBtnClick = onCancel,
+            onBackgroundPress = onDialogDismiss,
         ) {
             Column(
                 modifier = Modifier

--- a/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
@@ -128,6 +128,10 @@ fun MyPageScreen(
         mutableStateOf(false)
     }
 
+    val onSetProfileDialogDismiss = {
+        setProfileDialogState = false
+    }
+
     if (setProfileDialogState) {
         GettingImageOptionDialog(
             onCancel = {
@@ -143,6 +147,7 @@ fun MyPageScreen(
                     NavigationRoute.ConfirmImage + "/${SelectImageType.SELECT_FROM_GALLERY.ordinal}",
                 )
             },
+            onDialogDismiss = onSetProfileDialogDismiss,
         )
     }
 


### PR DESCRIPTION
## 개요
> 사진 선택의 모달의 배경을 눌렀을 때 다이얼로그가 취소되도록 합니다

## 작업사항
- 사진 선택 모달의 배경을 눌렀을 때 다이얼로그 취소 로직 구현

## 추가 로 할 말
