### PR TITLE
🔀 :: (#337) implement meal pager set by current time

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
@@ -54,7 +54,8 @@ fun ScrollEffectPager(
 
     var currentPageIndex by remember { mutableStateOf(0) }
 
-    currentPageIndex = when(MealType.getCurrentMealType(LocalDateTime.now())){
+    val currentMealType = MealType.getCurrentMealType(LocalDateTime.now())
+    currentPageIndex = when(currentMealType) {
         MealType.Breakfast -> 0
         MealType.Lunch -> 1
         else -> 2

--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
@@ -7,13 +7,23 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
-import androidx.compose.runtime.*
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,11 +37,12 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.calculateCurrentOffsetForPage
 import com.google.accompanist.pager.rememberPagerState
+import java.time.LocalDateTime
+import kotlin.math.absoluteValue
 import team.aliens.design_system.icon.DormIcon
 import team.aliens.design_system.theme.DormTheme
 import team.aliens.design_system.typography.Body4
 import team.aliens.dms_android.viewmodel.home.MealViewModel
-import kotlin.math.absoluteValue
 
 @SuppressLint("CoroutineCreationDuringComposition")
 @OptIn(ExperimentalPagerApi::class)
@@ -40,7 +51,16 @@ fun ScrollEffectPager(
     mealViewModel: MealViewModel,
 ) {
 
-    val pagerState = rememberPagerState()
+    var currentPageIndex by remember { mutableStateOf(0) }
+
+    currentPageIndex =
+        when (LocalDateTime.now().hour) {
+            in 0..8 -> 0
+            in 9..13 -> 1
+            else -> 2
+        }
+
+    val pagerState = rememberPagerState(currentPageIndex)
 
     val state = mealViewModel.state.collectAsState().value
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/cafeteria/MealContent.kt
@@ -43,6 +43,7 @@ import team.aliens.design_system.icon.DormIcon
 import team.aliens.design_system.theme.DormTheme
 import team.aliens.design_system.typography.Body4
 import team.aliens.dms_android.viewmodel.home.MealViewModel
+import team.aliens.dms_android.widget.meal.MealType
 
 @SuppressLint("CoroutineCreationDuringComposition")
 @OptIn(ExperimentalPagerApi::class)
@@ -53,12 +54,11 @@ fun ScrollEffectPager(
 
     var currentPageIndex by remember { mutableStateOf(0) }
 
-    currentPageIndex =
-        when (LocalDateTime.now().hour) {
-            in 0..8 -> 0
-            in 9..13 -> 1
-            else -> 2
-        }
+    currentPageIndex = when(MealType.getCurrentMealType(LocalDateTime.now())){
+        MealType.Breakfast -> 0
+        MealType.Lunch -> 1
+        else -> 2
+    }
 
     val pagerState = rememberPagerState(currentPageIndex)
 


### PR DESCRIPTION
## 개요
> 현재 시간에 따라 앱에 처음 진입했을때 급식 뷰페이저의 최초 페이지가 설정되는 로직을 구현했습니다.

## 작업사항
- 현재 시간이 0~8 인 경우 -> 아침
- 현재 시간이 9~13 인 경우 -> 점심
- 그 외의 경우 -> 저녁

## 추가 로 할 말
