### PR TITLE
🔀 :: (#333) refactor fetch studyroom list logic

### DIFF
--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -19,7 +19,8 @@ interface StudyRoomApi {
 
     @PUT(DmsUrl.StudyRoom.Apply)
     suspend fun applySeat(
-        @Path("seat-id") data: String,
+        @Path("seat-id") seatId: String,
+        @Query("time_slot") timeSlot: UUID?,
     )
 
     @GET(DmsUrl.StudyRoom.fetchApplyTime)
@@ -39,6 +40,7 @@ interface StudyRoomApi {
     @GET(DmsUrl.StudyRoom.StudyRoomDetail)
     suspend fun fetchStudyRoomDetail(
         @Path("study-room-id") roomId: String,
+        @Query("time_slot") timeSlot: UUID?,
     ): StudyRoomDetailResponse
 
     @GET(DmsUrl.StudyRoom.CurrentStudyRoomOption)

--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -6,7 +6,13 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
-import team.aliens.data.remote.response.studyroom.*
+import retrofit2.http.Query
+import team.aliens.data.remote.response.studyroom.ApplySeatTimeResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomTypeResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomListResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomDetailResponse
+import team.aliens.data.remote.response.studyroom.CurrentStudyRoomOptionResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomAvailableTimeListResponse
 import team.aliens.data.remote.url.DmsUrl
 
 interface StudyRoomApi {
@@ -24,7 +30,7 @@ interface StudyRoomApi {
 
     @GET(DmsUrl.StudyRoom.StudyRoomList)
     suspend fun fetchStudyRoomList(
-        timeSlot: UUID,
+        @Query("time_slot") timeSlot: UUID,
     ): StudyRoomListResponse
 
     @GET(DmsUrl.StudyRoom.StudyRoomType)

--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -27,11 +27,13 @@ interface StudyRoomApi {
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse
 
     @DELETE(DmsUrl.StudyRoom.CancelApply)
-    suspend fun cancelApplySeat(): Response<Unit>
+    suspend fun cancelApplySeat(
+        @Query("time_slot") timeSlot: UUID?,
+    ): Response<Unit>
 
     @GET(DmsUrl.StudyRoom.StudyRoomList)
     suspend fun fetchStudyRoomList(
-        @Query("time_slot") timeSlot: UUID,
+        @Query("time_slot") timeSlot: UUID?,
     ): StudyRoomListResponse
 
     @GET(DmsUrl.StudyRoom.StudyRoomType)

--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -21,7 +21,7 @@ interface StudyRoomApi {
     suspend fun applySeat(
         @Path("seat-id") seatId: String,
         @Query("time_slot") timeSlot: UUID?,
-    )
+    ): Response<Void>
 
     @GET(DmsUrl.StudyRoom.fetchApplyTime)
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse

--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -20,7 +20,7 @@ interface StudyRoomApi {
     @PUT(DmsUrl.StudyRoom.Apply)
     suspend fun applySeat(
         @Path("seat-id") seatId: String,
-        @Query("time_slot") timeSlot: UUID?,
+        @Query("time_slot") timeSlot: UUID,
     ): Response<Void>
 
     @GET(DmsUrl.StudyRoom.fetchApplyTime)
@@ -28,12 +28,12 @@ interface StudyRoomApi {
 
     @DELETE(DmsUrl.StudyRoom.CancelApply)
     suspend fun cancelApplySeat(
-        @Query("time_slot") timeSlot: UUID?,
+        @Query("time_slot") timeSlot: UUID,
     ): Response<Unit>
 
     @GET(DmsUrl.StudyRoom.StudyRoomList)
     suspend fun fetchStudyRoomList(
-        @Query("time_slot") timeSlot: UUID?,
+        @Query("time_slot") timeSlot: UUID,
     ): StudyRoomListResponse
 
     @GET(DmsUrl.StudyRoom.StudyRoomType)
@@ -42,7 +42,7 @@ interface StudyRoomApi {
     @GET(DmsUrl.StudyRoom.StudyRoomDetail)
     suspend fun fetchStudyRoomDetail(
         @Path("study-room-id") roomId: String,
-        @Query("time_slot") timeSlot: UUID?,
+        @Query("time_slot") timeSlot: UUID,
     ): StudyRoomDetailResponse
 
     @GET(DmsUrl.StudyRoom.CurrentStudyRoomOption)

--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -1,5 +1,6 @@
 package team.aliens.data.remote.api
 
+import java.util.UUID
 import retrofit2.Response
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -22,7 +23,9 @@ interface StudyRoomApi {
     suspend fun cancelApplySeat(): Response<Unit>
 
     @GET(DmsUrl.StudyRoom.StudyRoomList)
-    suspend fun fetchStudyRoomList(): StudyRoomListResponse
+    suspend fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ): StudyRoomListResponse
 
     @GET(DmsUrl.StudyRoom.StudyRoomType)
     suspend fun fetchStudyRoomType(): StudyRoomTypeResponse

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
@@ -1,6 +1,12 @@
 package team.aliens.data.remote.datasource.declaration
 
-import team.aliens.data.remote.response.studyroom.*
+import java.util.UUID
+import team.aliens.data.remote.response.studyroom.ApplySeatTimeResponse
+import team.aliens.data.remote.response.studyroom.CurrentStudyRoomOptionResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomAvailableTimeListResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomDetailResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomListResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomTypeResponse
 
 interface RemoteStudyRoomDataSource {
     suspend fun applySeat(data: String)
@@ -9,7 +15,9 @@ interface RemoteStudyRoomDataSource {
 
     suspend fun cancelApplySeat()
 
-    suspend fun fetchStudyRoomList(): StudyRoomListResponse
+    suspend fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ): StudyRoomListResponse
 
     suspend fun fetchStudyRoomType(): StudyRoomTypeResponse
 

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
@@ -9,7 +9,10 @@ import team.aliens.data.remote.response.studyroom.StudyRoomListResponse
 import team.aliens.data.remote.response.studyroom.StudyRoomTypeResponse
 
 interface RemoteStudyRoomDataSource {
-    suspend fun applySeat(data: String)
+    suspend fun applySeat(
+        seatId: String,
+        timeSlot: UUID?,
+    )
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse
 
@@ -21,7 +24,10 @@ interface RemoteStudyRoomDataSource {
 
     suspend fun fetchStudyRoomType(): StudyRoomTypeResponse
 
-    suspend fun fetchStudyRoomDetail(roomId: String): StudyRoomDetailResponse
+    suspend fun fetchStudyRoomDetail(
+        roomId: String,
+        timeSlot: UUID?,
+    ): StudyRoomDetailResponse
 
     suspend fun fetchCurrentStudyRoomOption(): CurrentStudyRoomOptionResponse
 

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
@@ -11,24 +11,24 @@ import team.aliens.data.remote.response.studyroom.StudyRoomTypeResponse
 interface RemoteStudyRoomDataSource {
     suspend fun applySeat(
         seatId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     )
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse
 
     suspend fun cancelApplySeat(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     )
 
     suspend fun fetchStudyRoomList(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ): StudyRoomListResponse
 
     suspend fun fetchStudyRoomType(): StudyRoomTypeResponse
 
     suspend fun fetchStudyRoomDetail(
         roomId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ): StudyRoomDetailResponse
 
     suspend fun fetchCurrentStudyRoomOption(): CurrentStudyRoomOptionResponse

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
@@ -16,10 +16,12 @@ interface RemoteStudyRoomDataSource {
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse
 
-    suspend fun cancelApplySeat()
+    suspend fun cancelApplySeat(
+        timeSlot: UUID?,
+    )
 
     suspend fun fetchStudyRoomList(
-        timeSlot: UUID,
+        timeSlot: UUID?,
     ): StudyRoomListResponse
 
     suspend fun fetchStudyRoomType(): StudyRoomTypeResponse

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -1,10 +1,11 @@
 package team.aliens.data.remote.datasource.implementation
 
+import java.util.UUID
+import javax.inject.Inject
 import team.aliens.data.remote.api.StudyRoomApi
 import team.aliens.data.remote.datasource.declaration.RemoteStudyRoomDataSource
 import team.aliens.data.remote.response.studyroom.StudyRoomAvailableTimeListResponse
 import team.aliens.data.util.sendHttpRequest
-import javax.inject.Inject
 
 class RemoteStudyRoomDataSourceImpl @Inject constructor(
     private val studyRoomApi: StudyRoomApi,
@@ -21,8 +22,15 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
         sendHttpRequest(httpRequest = suspend { studyRoomApi.cancelApplySeat() })
     }
 
-    override suspend fun fetchStudyRoomList() =
-        sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchStudyRoomList() })
+    override suspend fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ) = sendHttpRequest(
+        httpRequest = suspend {
+            studyRoomApi.fetchStudyRoomList(
+                timeSlot = timeSlot,
+            )
+        },
+    )
 
     override suspend fun fetchStudyRoomType() =
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchStudyRoomType() })

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -19,7 +19,7 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
             httpRequest = suspend {
                 studyRoomApi.applySeat(
                     seatId = seatId,
-                    timeSlot = timeSlot
+                    timeSlot = timeSlot,
                 )
             },
         )

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -13,7 +13,7 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
 
     override suspend fun applySeat(
         seatId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         sendHttpRequest(
             httpRequest = suspend {
@@ -29,7 +29,7 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchApplySeatTime() })
 
     override suspend fun cancelApplySeat(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         sendHttpRequest(
             httpRequest = suspend {
@@ -41,7 +41,7 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
     }
 
     override suspend fun fetchStudyRoomList(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) = sendHttpRequest(
         httpRequest = suspend {
             studyRoomApi.fetchStudyRoomList(
@@ -55,7 +55,7 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
 
     override suspend fun fetchStudyRoomDetail(
         roomId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) = sendHttpRequest(
         httpRequest = suspend {
             studyRoomApi.fetchStudyRoomDetail(

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -11,8 +11,18 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
     private val studyRoomApi: StudyRoomApi,
 ) : RemoteStudyRoomDataSource {
 
-    override suspend fun applySeat(data: String) {
-        sendHttpRequest(httpRequest = suspend { studyRoomApi.applySeat(data) })
+    override suspend fun applySeat(
+        seatId: String,
+        timeSlot: UUID?,
+    ) {
+        sendHttpRequest(
+            httpRequest = suspend {
+                studyRoomApi.applySeat(
+                    seatId = seatId,
+                    timeSlot = timeSlot
+                )
+            },
+        )
     }
 
     override suspend fun fetchApplySeatTime() =
@@ -35,8 +45,17 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
     override suspend fun fetchStudyRoomType() =
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchStudyRoomType() })
 
-    override suspend fun fetchStudyRoomDetail(roomId: String) =
-        sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchStudyRoomDetail(roomId) })
+    override suspend fun fetchStudyRoomDetail(
+        roomId: String,
+        timeSlot: UUID?,
+    ) = sendHttpRequest(
+        httpRequest = suspend {
+            studyRoomApi.fetchStudyRoomDetail(
+                roomId = roomId,
+                timeSlot = timeSlot,
+            )
+        },
+    )
 
     override suspend fun fetchCurrentStudyRoomOption() =
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchCurrentStudyRoomOption() })

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -28,12 +28,20 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
     override suspend fun fetchApplySeatTime() =
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchApplySeatTime() })
 
-    override suspend fun cancelApplySeat() {
-        sendHttpRequest(httpRequest = suspend { studyRoomApi.cancelApplySeat() })
+    override suspend fun cancelApplySeat(
+        timeSlot: UUID?,
+    ) {
+        sendHttpRequest(
+            httpRequest = suspend {
+                studyRoomApi.cancelApplySeat(
+                    timeSlot = timeSlot,
+                )
+            },
+        )
     }
 
     override suspend fun fetchStudyRoomList(
-        timeSlot: UUID,
+        timeSlot: UUID?,
     ) = sendHttpRequest(
         httpRequest = suspend {
             studyRoomApi.fetchStudyRoomList(

--- a/data/src/main/java/team/aliens/data/remote/response/studyroom/StudyRoomAvailableTimeListResponse.kt
+++ b/data/src/main/java/team/aliens/data/remote/response/studyroom/StudyRoomAvailableTimeListResponse.kt
@@ -5,9 +5,10 @@ import java.util.*
 
 data class StudyRoomAvailableTimeListResponse(
     @SerializedName("time_slots") val timeSlots: List<AvailableTime>,
-){
+) {
     data class AvailableTime(
         @SerializedName("id") val id: UUID,
-        @SerializedName("name") val name: String,
+        @SerializedName("start_time") val startTime: String,
+        @SerializedName("end_time") val endTime: String,
     )
 }

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -152,7 +152,8 @@ class StudyRoomRepositoryImpl @Inject constructor(
     private fun StudyRoomAvailableTimeListResponse.AvailableTime.toEntity() =
         StudyRoomAvailableTimeListEntity.AvailableTime(
             id = this.id,
-            name = this.name,
+            startTime = this.startTime,
+            endTime = this.endTime,
         )
 }
 

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -1,10 +1,21 @@
 package team.aliens.data.repository
 
-import team.aliens.data.remote.datasource.declaration.RemoteStudyRoomDataSource
-import team.aliens.data.remote.response.studyroom.*
-import team.aliens.domain.entity.studyroom.*
-import team.aliens.domain.repository.StudyRoomRepository
+import java.util.UUID
 import javax.inject.Inject
+import team.aliens.data.remote.datasource.declaration.RemoteStudyRoomDataSource
+import team.aliens.data.remote.response.studyroom.ApplySeatTimeResponse
+import team.aliens.data.remote.response.studyroom.CurrentStudyRoomOptionResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomAvailableTimeListResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomDetailResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomListResponse
+import team.aliens.data.remote.response.studyroom.StudyRoomTypeResponse
+import team.aliens.domain.entity.studyroom.ApplySeatTimeEntity
+import team.aliens.domain.entity.studyroom.CurrentStudyRoomOptionEntity
+import team.aliens.domain.entity.studyroom.SeatTypeEntity
+import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
+import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
+import team.aliens.domain.entity.studyroom.StudyRoomListEntity
+import team.aliens.domain.repository.StudyRoomRepository
 
 class StudyRoomRepositoryImpl @Inject constructor(
     private val remoteStudyRoomDataSource: RemoteStudyRoomDataSource,
@@ -21,8 +32,12 @@ class StudyRoomRepositoryImpl @Inject constructor(
         remoteStudyRoomDataSource.cancelApplySeat()
     }
 
-    override suspend fun fetchStudyRoomList(): StudyRoomListEntity =
-        remoteStudyRoomDataSource.fetchStudyRoomList().toEntity()
+    override suspend fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ): StudyRoomListEntity =
+        remoteStudyRoomDataSource.fetchStudyRoomList(
+            timeSlot = timeSlot,
+        ).toEntity()
 
     override suspend fun fetchStudyRoomType(): SeatTypeEntity =
         remoteStudyRoomDataSource.fetchStudyRoomType().toEntity()

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -15,14 +15,21 @@ import team.aliens.domain.entity.studyroom.SeatTypeEntity
 import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
 import team.aliens.domain.entity.studyroom.StudyRoomListEntity
+import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.StudyRoomDetailParam
 import team.aliens.domain.repository.StudyRoomRepository
 
 class StudyRoomRepositoryImpl @Inject constructor(
     private val remoteStudyRoomDataSource: RemoteStudyRoomDataSource,
 ) : StudyRoomRepository {
 
-    override suspend fun applySeat(data: String) {
-        remoteStudyRoomDataSource.applySeat(data)
+    override suspend fun applySeat(
+        applyStudyRoomParam: ApplyStudyRoomParam,
+    ) {
+        remoteStudyRoomDataSource.applySeat(
+            seatId = applyStudyRoomParam.seatId,
+            timeSlot = applyStudyRoomParam.timeSlot,
+        )
     }
 
     override suspend fun fetchApplySeatTime(): ApplySeatTimeEntity =
@@ -42,8 +49,14 @@ class StudyRoomRepositoryImpl @Inject constructor(
     override suspend fun fetchStudyRoomType(): SeatTypeEntity =
         remoteStudyRoomDataSource.fetchStudyRoomType().toEntity()
 
-    override suspend fun fetchStudyRoomDetail(roomId: String): StudyRoomDetailEntity =
-        remoteStudyRoomDataSource.fetchStudyRoomDetail(roomId).toEntity()
+    override suspend fun fetchStudyRoomDetail(
+        studyRoomDetailParam: StudyRoomDetailParam,
+    ): StudyRoomDetailEntity {
+        return remoteStudyRoomDataSource.fetchStudyRoomDetail(
+            roomId = studyRoomDetailParam.roomId,
+            timeSlot = studyRoomDetailParam.timeSlot,
+        ).toEntity()
+    }
 
     override suspend fun fetchCurrentStudyRoomOption(): CurrentStudyRoomOptionEntity =
         remoteStudyRoomDataSource.fetchCurrentStudyRoomOption().toEntity()

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -35,12 +35,16 @@ class StudyRoomRepositoryImpl @Inject constructor(
     override suspend fun fetchApplySeatTime(): ApplySeatTimeEntity =
         remoteStudyRoomDataSource.fetchApplySeatTime().toEntity()
 
-    override suspend fun cancelApplySeat() {
-        remoteStudyRoomDataSource.cancelApplySeat()
+    override suspend fun cancelApplySeat(
+        timeSlot: UUID?,
+    ) {
+        remoteStudyRoomDataSource.cancelApplySeat(
+            timeSlot = timeSlot,
+        )
     }
 
     override suspend fun fetchStudyRoomList(
-        timeSlot: UUID,
+        timeSlot: UUID?,
     ): StudyRoomListEntity =
         remoteStudyRoomDataSource.fetchStudyRoomList(
             timeSlot = timeSlot,

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -36,7 +36,7 @@ class StudyRoomRepositoryImpl @Inject constructor(
         remoteStudyRoomDataSource.fetchApplySeatTime().toEntity()
 
     override suspend fun cancelApplySeat(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         remoteStudyRoomDataSource.cancelApplySeat(
             timeSlot = timeSlot,
@@ -44,7 +44,7 @@ class StudyRoomRepositoryImpl @Inject constructor(
     }
 
     override suspend fun fetchStudyRoomList(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ): StudyRoomListEntity =
         remoteStudyRoomDataSource.fetchStudyRoomList(
             timeSlot = timeSlot,

--- a/design-system/src/main/java/team/aliens/design_system/dialog/dialog.kt
+++ b/design-system/src/main/java/team/aliens/design_system/dialog/dialog.kt
@@ -136,10 +136,15 @@ fun DormBottomAlignedContainedLargeButtonDialog(
     btnText: String,
     btnColor: DormButtonColor,
     onBtnClick: () -> Unit,
+    onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .dormClickable {
+                onDismissRequest()
+            },
         contentAlignment = Alignment.BottomCenter,
     ) {
         Column(

--- a/domain/src/main/java/team/aliens/domain/entity/studyroom/StudyRoomAvailableTimeListEntity.kt
+++ b/domain/src/main/java/team/aliens/domain/entity/studyroom/StudyRoomAvailableTimeListEntity.kt
@@ -7,6 +7,7 @@ data class StudyRoomAvailableTimeListEntity(
 ){
     data class AvailableTime(
         val id: UUID,
-        val name: String,
+        val startTime: String,
+        val endTime: String,
     )
 }

--- a/domain/src/main/java/team/aliens/domain/param/ApplyStudyRoomParam.kt
+++ b/domain/src/main/java/team/aliens/domain/param/ApplyStudyRoomParam.kt
@@ -4,5 +4,5 @@ import java.util.UUID
 
 data class ApplyStudyRoomParam(
     val seatId: String,
-    val timeSlot: UUID?,
+    val timeSlot: UUID,
 )

--- a/domain/src/main/java/team/aliens/domain/param/ApplyStudyRoomParam.kt
+++ b/domain/src/main/java/team/aliens/domain/param/ApplyStudyRoomParam.kt
@@ -1,0 +1,8 @@
+package team.aliens.domain.param
+
+import java.util.UUID
+
+data class ApplyStudyRoomParam(
+    val seatId: String,
+    val timeSlot: UUID?,
+)

--- a/domain/src/main/java/team/aliens/domain/param/StudyRoomDetailParam.kt
+++ b/domain/src/main/java/team/aliens/domain/param/StudyRoomDetailParam.kt
@@ -1,0 +1,8 @@
+package team.aliens.domain.param
+
+import java.util.UUID
+
+data class StudyRoomDetailParam(
+    val roomId: String,
+    val timeSlot: UUID?,
+)

--- a/domain/src/main/java/team/aliens/domain/param/StudyRoomDetailParam.kt
+++ b/domain/src/main/java/team/aliens/domain/param/StudyRoomDetailParam.kt
@@ -4,5 +4,5 @@ import java.util.UUID
 
 data class StudyRoomDetailParam(
     val roomId: String,
-    val timeSlot: UUID?,
+    val timeSlot: UUID,
 )

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -1,6 +1,12 @@
 package team.aliens.domain.repository
 
-import team.aliens.domain.entity.studyroom.*
+import java.util.UUID
+import team.aliens.domain.entity.studyroom.ApplySeatTimeEntity
+import team.aliens.domain.entity.studyroom.CurrentStudyRoomOptionEntity
+import team.aliens.domain.entity.studyroom.SeatTypeEntity
+import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
+import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
+import team.aliens.domain.entity.studyroom.StudyRoomListEntity
 
 interface StudyRoomRepository {
 
@@ -10,7 +16,9 @@ interface StudyRoomRepository {
 
     suspend fun cancelApplySeat()
 
-    suspend fun fetchStudyRoomList(): StudyRoomListEntity
+    suspend fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ): StudyRoomListEntity
 
     suspend fun fetchStudyRoomType(): SeatTypeEntity
 

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -7,10 +7,12 @@ import team.aliens.domain.entity.studyroom.SeatTypeEntity
 import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
 import team.aliens.domain.entity.studyroom.StudyRoomListEntity
+import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.StudyRoomDetailParam
 
 interface StudyRoomRepository {
 
-    suspend fun applySeat(data: String)
+    suspend fun applySeat(applyStudyRoomParam: ApplyStudyRoomParam)
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeEntity
 
@@ -22,7 +24,9 @@ interface StudyRoomRepository {
 
     suspend fun fetchStudyRoomType(): SeatTypeEntity
 
-    suspend fun fetchStudyRoomDetail(roomId: String): StudyRoomDetailEntity
+    suspend fun fetchStudyRoomDetail(
+        studyRoomDetailParam: StudyRoomDetailParam,
+    ): StudyRoomDetailEntity
 
     suspend fun fetchCurrentStudyRoomOption(): CurrentStudyRoomOptionEntity
 

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -17,11 +17,11 @@ interface StudyRoomRepository {
     suspend fun fetchApplySeatTime(): ApplySeatTimeEntity
 
     suspend fun cancelApplySeat(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     )
 
     suspend fun fetchStudyRoomList(
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ): StudyRoomListEntity
 
     suspend fun fetchStudyRoomType(): SeatTypeEntity

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -16,10 +16,12 @@ interface StudyRoomRepository {
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeEntity
 
-    suspend fun cancelApplySeat()
+    suspend fun cancelApplySeat(
+        timeSlot: UUID?,
+    )
 
     suspend fun fetchStudyRoomList(
-        timeSlot: UUID,
+        timeSlot: UUID?,
     ): StudyRoomListEntity
 
     suspend fun fetchStudyRoomType(): SeatTypeEntity

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteApplySeatUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteApplySeatUseCase.kt
@@ -3,11 +3,14 @@ package team.aliens.domain.usecase.studyroom
 import team.aliens.domain.repository.StudyRoomRepository
 import team.aliens.domain.usecase.UseCase
 import javax.inject.Inject
+import team.aliens.domain.param.ApplyStudyRoomParam
 
 class RemoteApplySeatUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<String, Unit>() {
-    override suspend fun execute(data: String) {
-        studyRoomRepository.applySeat(data)
+) : UseCase<ApplyStudyRoomParam, Unit>() {
+    override suspend fun execute(data: ApplyStudyRoomParam) {
+        studyRoomRepository.applySeat(
+            applyStudyRoomParam = data,
+        )
     }
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteApplySeatUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteApplySeatUseCase.kt
@@ -8,9 +8,9 @@ import team.aliens.domain.param.ApplyStudyRoomParam
 class RemoteApplySeatUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
 ) : UseCase<ApplyStudyRoomParam, Unit>() {
-    override suspend fun execute(data: ApplyStudyRoomParam) {
+    override suspend fun execute(applyStudyRoomParam: ApplyStudyRoomParam) {
         studyRoomRepository.applySeat(
-            applyStudyRoomParam = data,
+            applyStudyRoomParam = applyStudyRoomParam,
         )
     }
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
@@ -7,8 +7,8 @@ import javax.inject.Inject
 
 class RemoteCancelApplySeatUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<UUID?, Unit>() {
-    override suspend fun execute(data: UUID?) {
+) : UseCase<UUID, Unit>() {
+    override suspend fun execute(data: UUID) {
         studyRoomRepository.cancelApplySeat(
             timeSlot = data,
         )

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
@@ -1,13 +1,16 @@
 package team.aliens.domain.usecase.studyroom
 
+import java.util.UUID
 import team.aliens.domain.repository.StudyRoomRepository
 import team.aliens.domain.usecase.UseCase
 import javax.inject.Inject
 
 class RemoteCancelApplySeatUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<Unit, Unit>() {
-    override suspend fun execute(data: Unit) {
-        studyRoomRepository.cancelApplySeat()
+) : UseCase<UUID?, Unit>() {
+    override suspend fun execute(data: UUID?) {
+        studyRoomRepository.cancelApplySeat(
+            timeSlot = data,
+        )
     }
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomDetailUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomDetailUseCase.kt
@@ -9,8 +9,8 @@ import team.aliens.domain.usecase.UseCase
 class RemoteFetchStudyRoomDetailUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
 ) : UseCase<StudyRoomDetailParam, StudyRoomDetailEntity>() {
-    override suspend fun execute(data: StudyRoomDetailParam): StudyRoomDetailEntity =
+    override suspend fun execute(studyRoomDetailParam: StudyRoomDetailParam): StudyRoomDetailEntity =
         studyRoomRepository.fetchStudyRoomDetail(
-            studyRoomDetailParam = data,
+            studyRoomDetailParam = studyRoomDetailParam,
         )
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomDetailUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomDetailUseCase.kt
@@ -1,13 +1,16 @@
 package team.aliens.domain.usecase.studyroom
 
+import javax.inject.Inject
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
+import team.aliens.domain.param.StudyRoomDetailParam
 import team.aliens.domain.repository.StudyRoomRepository
 import team.aliens.domain.usecase.UseCase
-import javax.inject.Inject
 
 class RemoteFetchStudyRoomDetailUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<String, StudyRoomDetailEntity>() {
-    override suspend fun execute(data: String): StudyRoomDetailEntity =
-        studyRoomRepository.fetchStudyRoomDetail(data)
+) : UseCase<StudyRoomDetailParam, StudyRoomDetailEntity>() {
+    override suspend fun execute(data: StudyRoomDetailParam): StudyRoomDetailEntity =
+        studyRoomRepository.fetchStudyRoomDetail(
+            studyRoomDetailParam = data,
+        )
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
@@ -8,8 +8,8 @@ import team.aliens.domain.usecase.UseCase
 
 class RemoteFetchStudyRoomListUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<UUID?, StudyRoomListEntity>() {
-    override suspend fun execute(data: UUID?): StudyRoomListEntity =
+) : UseCase<UUID, StudyRoomListEntity>() {
+    override suspend fun execute(data: UUID): StudyRoomListEntity =
         studyRoomRepository.fetchStudyRoomList(
             timeSlot = data,
         )

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
@@ -1,13 +1,16 @@
 package team.aliens.domain.usecase.studyroom
 
+import java.util.UUID
+import javax.inject.Inject
 import team.aliens.domain.entity.studyroom.StudyRoomListEntity
 import team.aliens.domain.repository.StudyRoomRepository
 import team.aliens.domain.usecase.UseCase
-import javax.inject.Inject
 
 class RemoteFetchStudyRoomListUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<Unit, StudyRoomListEntity>() {
-    override suspend fun execute(data: Unit): StudyRoomListEntity =
-        studyRoomRepository.fetchStudyRoomList()
+) : UseCase<UUID, StudyRoomListEntity>() {
+    override suspend fun execute(data: UUID): StudyRoomListEntity =
+        studyRoomRepository.fetchStudyRoomList(
+            timeSlot = data,
+        )
 }

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteFetchStudyRoomListUseCase.kt
@@ -8,8 +8,8 @@ import team.aliens.domain.usecase.UseCase
 
 class RemoteFetchStudyRoomListUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<UUID, StudyRoomListEntity>() {
-    override suspend fun execute(data: UUID): StudyRoomListEntity =
+) : UseCase<UUID?, StudyRoomListEntity>() {
+    override suspend fun execute(data: UUID?): StudyRoomListEntity =
         studyRoomRepository.fetchStudyRoomList(
             timeSlot = data,
         )

--- a/presentation/src/main/java/team/aliens/dms_android/feature/image/ConfirmImageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/image/ConfirmImageScreen.kt
@@ -43,6 +43,12 @@ internal fun ConfirmImageScreen(
 
     val scope = rememberCoroutineScope()
 
+    var confirmButtonState by remember {
+        mutableStateOf(false)
+    }
+
+    confirmButtonState = confirmImageViewModel.confirmImageButtonState.collectAsState().value
+
     LaunchedEffect(Unit) {
         confirmImageViewModel.confirmImageEvent.collect {
             when (it) {
@@ -101,6 +107,7 @@ internal fun ConfirmImageScreen(
                     val selectedImage = fetchImage(context) ?: return@launch
 
                     confirmImageViewModel.setImage(selectedImage)
+                    confirmImageViewModel.setConfirmButtonState(true)
 
                     gettingImageOptionDialogState = false
                 }
@@ -174,6 +181,7 @@ internal fun ConfirmImageScreen(
             DormContainedLargeButton(
                 text = stringResource(R.string.Check),
                 color = DormButtonColor.Blue,
+                enabled = confirmButtonState,
             ) {
                 confirmImageViewModel.editProfileImage()
             }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/NavigationRoute.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/NavigationRoute.kt
@@ -17,7 +17,7 @@ object NavigationRoute {
     const val PointList = "pointList"
     const val StudyRoom = "studyRoom"
     const val RemainApplication = "remainApplication"
-    const val StudyRoomDetail = "studyRoomDetail/{seatId}"
+    const val StudyRoomDetail = "studyRoomDetail/{seatId}/{timeSlot}"
     const val ConfirmImage = "confirmImage"
     const val ComparePassword = "comparePassword"
     const val VerifySchool = "verifySchool"

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/RootDms.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import java.util.*
 import team.aliens.design_system.theme.DormTheme
 import team.aliens.dms_android.feature.auth.changepassword.ChangePasswordScreen
 import team.aliens.dms_android.feature.auth.changepassword.ChangePasswordVerifyEmailScreen
@@ -103,13 +104,16 @@ fun RootDms(
                 route = NavigationRoute.StudyRoomDetail,
                 arguments = listOf(
                     navArgument("seatId") { type = NavType.StringType },
+                    navArgument("timeSlot") { type = NavType.StringType },
                 ),
             ) {
                 val roomId = it.arguments!!.getString("seatId")
+                val timeSlot = it.arguments!!.getString("timeSlot")
                 if (roomId != null) {
                     StudyRoomDetailScreen(
                         navController = navController,
                         roomId = roomId,
+                        timeSlot = UUID.fromString(timeSlot),
                     )
                 }
             }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
@@ -191,6 +191,7 @@ fun StudyRoomDetailScreen(
                             event = StudyRoomDetailsViewModel.UiEvent.ApplySeat(
                                 seat = currentSeat,
                                 timeSlot = timeSlot,
+                            ),
                         )
                     }
                 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
@@ -39,7 +39,7 @@ import team.aliens.presentation.R
 fun StudyRoomDetailScreen(
     navController: NavController,
     roomId: String,
-    timeSlot: UUID?,
+    timeSlot: UUID,
     studyRoomDetailsViewModel: StudyRoomDetailsViewModel = hiltViewModel(),
 ) {
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
@@ -243,7 +243,7 @@ private fun StudyRoomDetailEntity.toDesignSystemModel(): List<List<SeatItem>> {
             color = if (color != null) {
                 getColor(color)
             } else DormColor.DormPrimary,
-            type = SeatType.toSeatType(seat.status)
+            type = SeatType.toSeatType(seat.status),
         )
     }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import java.util.*
 import kotlinx.coroutines.launch
 import team.aliens.design_system.button.DormButtonColor
 import team.aliens.design_system.button.DormContainedLargeButton
@@ -38,12 +39,14 @@ import team.aliens.presentation.R
 fun StudyRoomDetailScreen(
     navController: NavController,
     roomId: String,
+    timeSlot: UUID?,
     studyRoomDetailsViewModel: StudyRoomDetailsViewModel = hiltViewModel(),
 ) {
 
     LaunchedEffect(Unit) {
         studyRoomDetailsViewModel.initStudyRoom(
-            studyRoomId = roomId,
+            roomId = roomId,
+            timeSlot = timeSlot,
         )
     }
 
@@ -192,10 +195,12 @@ fun StudyRoomDetailScreen(
                                 context.getString(R.string.PleaseSelectSeatFirst),
                             )
                         }
-
-                        studyRoomDetailsViewModel.onEvent(event = StudyRoomDetailsViewModel.UiEvent.ApplySeat(
-                            seat = currentSeat,
-                        ))
+                        studyRoomDetailsViewModel.onEvent(
+                            event = StudyRoomDetailsViewModel.UiEvent.ApplySeat(
+                                seat = currentSeat,
+                                timeSlot = timeSlot,
+                            )
+                        )
                     }
                 }
             }
@@ -231,13 +236,15 @@ private fun StudyRoomDetailEntity.toDesignSystemModel(): List<List<SeatItem>> {
         val height = seat.heightLocation - 1
         val color = seat.type?.color
 
-        defaultSeats[height][width] = SeatItem(id = seat.id,
+        defaultSeats[height][width] = SeatItem(
+            id = seat.id,
             number = seat.number,
             name = seat.student?.name,
             color = if (color != null) {
                 getColor(color)
             } else DormColor.DormPrimary,
-            type = SeatType.toSeatType(seat.status))
+            type = SeatType.toSeatType(seat.status)
+        )
     }
 
     return defaultSeats

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -5,27 +5,26 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -35,6 +34,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -51,6 +51,7 @@ import team.aliens.design_system.typography.ButtonText
 import team.aliens.design_system.typography.Title3
 import team.aliens.dms_android.component.FloatingNotice
 import team.aliens.dms_android.util.TopBar
+import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.presentation.R
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -64,18 +65,17 @@ fun StudyRoomListScreen(
 
     val studyRoomState = studyRoomListViewModel.uiState.collectAsState().value
 
-    //val studyRoomAvailableTimeList = studyRoomState.studyRoomAvailableTime
+    val studyRoomAvailableTimeList = studyRoomState.studyRoomAvailableTime
 
     var selectedTime by remember { mutableStateOf(0) }
 
-    val studyRoomAvailableTimeList = arrayListOf(
-        "10시 ~ 11시",
-        "11시 ~ 12시",
-        "12시 ~ 13시 50분",
-        "14시 ~ 15시"
-    ) // TODO remove after complete api document
+    var selectedAvailableTime by remember { mutableStateOf("") }
 
-    var selectedAvailableTime by remember { mutableStateOf(studyRoomAvailableTimeList[0]) }
+    LaunchedEffect(studyRoomAvailableTimeList) {
+        if (studyRoomAvailableTimeList.isNotEmpty()) {
+            selectedAvailableTime = setAvailableTime(studyRoomAvailableTimeList.first())
+        }
+    }
 
     LaunchedEffect(Unit) {
         studyRoomListViewModel.errorState.collect {
@@ -103,8 +103,9 @@ fun StudyRoomListScreen(
                 btnColor = DormButtonColor.Blue,
                 onBtnClick = {
                     showTimeFilterDialogState = false
-                    selectedAvailableTime = studyRoomAvailableTimeList[selectedTime]
-                    //studyRoomListViewModel.setStudyRoomAvailableTime(studyRoomAvailableTimeList[selectedTime].id)
+                    selectedAvailableTime =
+                        setAvailableTime(studyRoomAvailableTimeList[selectedTime])
+                    studyRoomListViewModel.setStudyRoomAvailableTime(studyRoomAvailableTimeList[selectedTime].id)
                 },
             ) {
 
@@ -122,7 +123,9 @@ fun StudyRoomListScreen(
                         items(studyRoomAvailableTimeList.size) {
                             DormTimeChip(
                                 selected = (selectedTime == it),
-                                text = studyRoomAvailableTimeList[it],
+                                text = setAvailableTime(
+                                    studyRoomAvailableTimeList[it],
+                                ),
                                 onClick = {
                                     selectedTime = it
                                 },
@@ -133,7 +136,6 @@ fun StudyRoomListScreen(
             }
         }
     }
-
 
     Column(
         modifier = Modifier
@@ -163,7 +165,6 @@ fun StudyRoomListScreen(
             Spacer(
                 modifier = Modifier.height(17.dp),
             )
-
 
             // Available study room application time
             FloatingNotice(
@@ -196,7 +197,7 @@ fun StudyRoomListScreen(
 
                 // available time
                 Body3(
-                    text = selectedAvailableTime, // todo sync with server
+                    text = selectedAvailableTime,
                     color = DormColor.DormPrimary,
                 )
             }
@@ -234,7 +235,6 @@ fun StudyRoomListScreen(
                     }
                 }
             }
-
 
             Spacer(
                 modifier = Modifier.height(24.dp),
@@ -285,3 +285,7 @@ fun DormTimeChip(
         )
     }
 }
+
+private fun setAvailableTime(
+    studyRoomAvailableTimeList: StudyRoomAvailableTimeListEntity.AvailableTime,
+): String = "${studyRoomAvailableTimeList.startTime} ~ ${studyRoomAvailableTimeList.endTime}"

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -1,31 +1,17 @@
 package team.aliens.dms_android.feature.studyroom
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -35,7 +21,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -73,7 +58,7 @@ fun StudyRoomListScreen(
 
     var selectedAvailableTime by remember { mutableStateOf("") }
 
-    var showTimeFilterDialogState by remember { mutableStateOf(false)}
+    var showTimeFilterDialogState by remember { mutableStateOf(false) }
 
     LaunchedEffect(studyRoomAvailableTimeList) {
         if (studyRoomAvailableTimeList.isNotEmpty()) {
@@ -100,13 +85,11 @@ fun StudyRoomListScreen(
             val studyRoomFirstEntity = studyRoomAvailableTimeList.first()
 
             selectedAvailableTime = setAvailableTime(studyRoomFirstEntity)
+
             studyRoomListViewModel.onEvent(
-                event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
-                    timeSlot = studyRoomFirstEntity.id,
+                event = StudyRoomListViewModel.UiEvent.FetchStudyRooms(
+                    timeSlot = studyRoomAvailableTimeList.first().id,
                 )
-            )
-            studyRoomListViewModel.onEvent(
-                event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
             )
         }
     }
@@ -130,7 +113,7 @@ fun StudyRoomListScreen(
                     selectedAvailableTime =
                         setAvailableTime(studyRoomAvailableTimeList[selectedAvailableTimeItemIndex])
                     studyRoomListViewModel.onEvent(
-                        event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
+                        event = StudyRoomListViewModel.UiEvent.FetchStudyRooms(
                             timeSlot = studyRoomAvailableTimeList[selectedAvailableTimeItemIndex].id,
                         ),
                     )
@@ -156,15 +139,10 @@ fun StudyRoomListScreen(
                             DormTimeChip(
                                 selected = (selectedAvailableTimeItemIndex == index),
                                 text = setAvailableTime(
-                                    studyRoomAvailableTimeList[index],
+                                    studyRoomAvailableTimeList = items,
                                 ),
                                 onClick = {
                                     selectedAvailableTimeItemIndex = index
-                                    studyRoomListViewModel.onEvent(
-                                        event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
-                                            timeSlot = items.id,
-                                        )
-                                    )
                                 },
                             )
                         }
@@ -202,7 +180,9 @@ fun StudyRoomListScreen(
             Space(space = 17.dp)
 
             // Available study room application time
-            if (studyRoomState.hasApplyTime) {
+            AnimatedVisibility(
+                visible = studyRoomState.hasApplyTime,
+            ) {
                 FloatingNotice(
                     content = stringResource(
                         id = R.string.study_room_apply_time,

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -101,17 +101,12 @@ fun StudyRoomListScreen(
                 ),
                 btnColor = DormButtonColor.Blue,
                 onBtnClick = {
-                    with(studyRoomListViewModel) {
-                        showTimeFilterDialogState = false
-                        selectedAvailableTime =
-                            setAvailableTime(studyRoomAvailableTimeList[selectedIndex])
-                        onEvent(
-                            event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
-                                timeSlot = studyRoomAvailableTimeList[selectedIndex].id,
-                            )
-                        )
-                        fetchStudyRoomAvailableTimeList()
-                    }
+                    showTimeFilterDialogState = false
+                    selectedAvailableTime =
+                        setAvailableTime(studyRoomAvailableTimeList[selectedIndex])
+                    studyRoomListViewModel.onEvent(
+                        event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
+                    )
                 },
             ) {
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -52,7 +52,7 @@ fun StudyRoomListScreen(
 
     val studyRoomAvailableTimeList = studyRoomState.studyRoomAvailableTime
 
-    var selectedIndex by remember { mutableStateOf(0) }
+    var selectedAvailableTimeItemIndex by remember { mutableStateOf(0) }
 
     var selectedAvailableTime by remember { mutableStateOf("") }
 
@@ -107,7 +107,7 @@ fun StudyRoomListScreen(
                 onBtnClick = {
                     showTimeFilterDialogState = false
                     selectedAvailableTime =
-                        setAvailableTime(studyRoomAvailableTimeList[selectedIndex])
+                        setAvailableTime(studyRoomAvailableTimeList[selectedAvailableTimeItemIndex])
                     studyRoomListViewModel.onEvent(
                         event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
                     )
@@ -130,12 +130,12 @@ fun StudyRoomListScreen(
                             items = studyRoomAvailableTimeList,
                         ) { index, items ->
                             DormTimeChip(
-                                selected = (selectedIndex == index),
+                                selected = (selectedAvailableTimeItemIndex == index),
                                 text = setAvailableTime(
                                     studyRoomAvailableTimeList[index],
                                 ),
                                 onClick = {
-                                    selectedIndex = index
+                                    selectedAvailableTimeItemIndex = index
                                     studyRoomListViewModel.onEvent(
                                         event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
                                             timeSlot = items.id,
@@ -182,7 +182,10 @@ fun StudyRoomListScreen(
             // Available study room application time
             if (studyRoomState.hasApplyTime) {
                 FloatingNotice(
-                    content = "자습실 신청 가능 시간 : ${studyRoomState.startAt} ~ ${studyRoomState.endAt}",
+                    content = stringResource(
+                        id = R.string.study_room_apply_time,
+                        "${studyRoomState.startAt} ~ ${studyRoomState.endAt}"
+                    )
                 )
             }
 
@@ -214,7 +217,7 @@ fun StudyRoomListScreen(
                     // available time
                     Body3(
                         text = selectedAvailableTime,
-                        color = DormColor.DormPrimary,
+                        color = DormTheme.colors.primary,
                     )
                 }
 
@@ -241,7 +244,7 @@ fun StudyRoomListScreen(
                             maxNumber = point.maxNumber,
                             condition = point.condition,
                             onClick = { seatId ->
-                                navController.navigate("studyRoomDetail/${seatId}/${studyRoomAvailableTimeList[selectedIndex].id}")
+                                navController.navigate("studyRoomDetail/${seatId}/${studyRoomAvailableTimeList[selectedAvailableTimeItemIndex].id}")
                             },
                         )
                     }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -233,7 +233,7 @@ fun StudyRoomListScreen(
                             maxNumber = point.maxNumber,
                             condition = point.condition,
                             onClick = { seatId ->
-                                navController.navigate("studyRoomDetail/${seatId}")
+                                navController.navigate("studyRoomDetail/${seatId}/${studyRoomAvailableTimeList[selectedIndex].id}")
                             },
                         )
                     }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -62,7 +62,7 @@ fun StudyRoomListScreen(
 
     LaunchedEffect(studyRoomAvailableTimeList) {
         if (studyRoomAvailableTimeList.isNotEmpty()) {
-            selectedAvailableTime = setAvailableTime(studyRoomAvailableTimeList.first())
+            selectedAvailableTime = makeTimeRange(studyRoomAvailableTimeList.first())
         }
     }
 
@@ -84,7 +84,7 @@ fun StudyRoomListScreen(
 
             val studyRoomFirstEntity = studyRoomAvailableTimeList.first()
 
-            selectedAvailableTime = setAvailableTime(studyRoomFirstEntity)
+            selectedAvailableTime = makeTimeRange(studyRoomFirstEntity)
 
             studyRoomListViewModel.onEvent(
                 event = StudyRoomListViewModel.UiEvent.FetchStudyRooms(
@@ -111,7 +111,7 @@ fun StudyRoomListScreen(
                 onBtnClick = {
                     showTimeFilterDialogState = false
                     selectedAvailableTime =
-                        setAvailableTime(studyRoomAvailableTimeList[selectedAvailableTimeItemIndex])
+                        makeTimeRange(studyRoomAvailableTimeList[selectedAvailableTimeItemIndex])
                     studyRoomListViewModel.onEvent(
                         event = StudyRoomListViewModel.UiEvent.FetchStudyRooms(
                             timeSlot = studyRoomAvailableTimeList[selectedAvailableTimeItemIndex].id,
@@ -138,7 +138,7 @@ fun StudyRoomListScreen(
                         ) { index, items ->
                             DormTimeChip(
                                 selected = (selectedAvailableTimeItemIndex == index),
-                                text = setAvailableTime(
+                                text = makeTimeRange(
                                     studyRoomAvailableTimeList = items,
                                 ),
                                 onClick = {
@@ -273,7 +273,7 @@ fun DormTimeChip(
             .wrapContentWidth()
             .background(
                 color = when {
-                    selected -> DormColor.DormPrimary
+                    selected -> DormTheme.colors.primary
                     else -> Color.Transparent
                 },
                 shape = DormTimeChipShape,
@@ -296,11 +296,11 @@ fun DormTimeChip(
         ButtonText(
             text = text,
             modifier = Modifier.padding(8.dp),
-            color = if (selected) DormColor.Gray100 else DormColor.Gray400
+            color = if (selected) DormTheme.colors.onPrimary else DormColor.Gray400
         )
     }
 }
 
-private fun setAvailableTime(
+private fun makeTimeRange(
     studyRoomAvailableTimeList: StudyRoomAvailableTimeListEntity.AvailableTime,
 ): String = "${studyRoomAvailableTimeList.startTime} ~ ${studyRoomAvailableTimeList.endTime}"

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -4,13 +4,28 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -20,6 +35,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -57,8 +73,12 @@ fun StudyRoomListScreen(
 
     var selectedAvailableTime by remember { mutableStateOf("") }
 
-    var showTimeFilterDialogState by remember {
-        mutableStateOf(false)
+    var showTimeFilterDialogState by remember { mutableStateOf(false)}
+
+    LaunchedEffect(studyRoomAvailableTimeList) {
+        if (studyRoomAvailableTimeList.isNotEmpty()) {
+            selectedAvailableTime = setAvailableTime(studyRoomAvailableTimeList.first())
+        }
     }
 
     val onStudyRoomFilterDialogDismiss = {
@@ -110,7 +130,9 @@ fun StudyRoomListScreen(
                     selectedAvailableTime =
                         setAvailableTime(studyRoomAvailableTimeList[selectedAvailableTimeItemIndex])
                     studyRoomListViewModel.onEvent(
-                        event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
+                        event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
+                            timeSlot = studyRoomAvailableTimeList[selectedAvailableTimeItemIndex].id,
+                        ),
                     )
                 },
                 onDismissRequest = onStudyRoomFilterDialogDismiss,
@@ -218,11 +240,6 @@ fun StudyRoomListScreen(
                         color = DormTheme.colors.primary,
                     )
                 }
-
-                Spacer(
-                    modifier = Modifier.height(24.dp),
-                )
-
             }
 
             Space(space = 24.dp)

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -4,29 +4,13 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -91,6 +75,9 @@ fun StudyRoomListScreen(
                 event = StudyRoomListViewModel.UiEvent.SetStudyRoomAvailableTime(
                     timeSlot = studyRoomFirstEntity.id,
                 )
+            )
+            studyRoomListViewModel.onEvent(
+                event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
             )
         }
     }
@@ -193,9 +180,11 @@ fun StudyRoomListScreen(
             )
 
             // Available study room application time
-            FloatingNotice(
-                content = "자습실 신청 가능 시간 : ${studyRoomState.startAt} ~ ${studyRoomState.endAt}",
-            )
+            if (studyRoomState.hasApplyTime) {
+                FloatingNotice(
+                    content = "자습실 신청 가능 시간 : ${studyRoomState.startAt} ~ ${studyRoomState.endAt}",
+                )
+            }
 
             Spacer(
                 modifier = Modifier.height(24.dp),

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -56,6 +56,14 @@ fun StudyRoomListScreen(
 
     var selectedAvailableTime by remember { mutableStateOf("") }
 
+    var showTimeFilterDialogState by remember {
+        mutableStateOf(false)
+    }
+
+    val onStudyRoomFilterDialogDismiss = {
+        showTimeFilterDialogState = false
+    }
+
     LaunchedEffect(Unit) {
         with(studyRoomListViewModel) {
             onEvent(event = StudyRoomListViewModel.UiEvent.FetchStudyRoomAvailableTimes)
@@ -82,10 +90,6 @@ fun StudyRoomListScreen(
         }
     }
 
-    var showTimeFilterDialogState by remember {
-        mutableStateOf(false)
-    }
-
     if (showTimeFilterDialogState) {
         DormCustomDialog(
             onDismissRequest = {
@@ -108,6 +112,7 @@ fun StudyRoomListScreen(
                         event = StudyRoomListViewModel.UiEvent.FetchStudyRooms,
                     )
                 },
+                onDismissRequest = onStudyRoomFilterDialogDismiss,
             ) {
 
                 Title3(
@@ -186,35 +191,38 @@ fun StudyRoomListScreen(
             )
 
             // Study room time filter
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
+            if (studyRoomAvailableTimeList.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
 
-                // slider icon
-                Image(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .dormClickable {
-                            showTimeFilterDialogState = true
-                        },
-                    painter = painterResource(
-                        id = R.drawable.ic_slider,
-                    ),
-                    contentDescription = null,
+                    // slider icon
+                    Image(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .dormClickable {
+                                showTimeFilterDialogState = true
+                            },
+                        painter = painterResource(
+                            id = R.drawable.ic_slider,
+                        ),
+                        contentDescription = null,
+                    )
+
+                    // available time
+                    Body3(
+                        text = selectedAvailableTime,
+                        color = DormColor.DormPrimary,
+                    )
+                }
+
+                Spacer(
+                    modifier = Modifier.height(24.dp),
                 )
 
-                // available time
-                Body3(
-                    text = selectedAvailableTime,
-                    color = DormColor.DormPrimary,
-                )
             }
-
-            Spacer(
-                modifier = Modifier.height(24.dp),
-            )
 
             // List of study rooms
             LazyColumn(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListScreen.kt
@@ -104,6 +104,7 @@ fun StudyRoomListScreen(
                 onBtnClick = {
                     showTimeFilterDialogState = false
                     selectedAvailableTime = studyRoomAvailableTimeList[selectedTime]
+                    //studyRoomListViewModel.setStudyRoomAvailableTime(studyRoomAvailableTimeList[selectedTime].id)
                 },
             ) {
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListUiState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListUiState.kt
@@ -12,6 +12,7 @@ data class StudyRoomListUiState(
     var studyRooms: List<StudyRoomInformation> = emptyList(),
     var studyRoomAvailableTime: List<StudyRoomAvailableTimeListEntity.AvailableTime> = emptyList(),
     var timeSlot: UUID? = null,
+    var hasApplyTime: Boolean = false,
 ) : BaseUiState
 
 data class StudyRoomDetailsUiState(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListUiState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListUiState.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms_android.feature.studyroom
 
+import java.util.UUID
 import team.aliens.dms_android._base.BaseUiState
 import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
@@ -10,6 +11,7 @@ data class StudyRoomListUiState(
     var endAt: String = "",
     var studyRooms: List<StudyRoomInformation> = emptyList(),
     var studyRoomAvailableTime: List<StudyRoomAvailableTimeListEntity.AvailableTime> = emptyList(),
+    var timeSlot: UUID? = null,
 ) : BaseUiState
 
 data class StudyRoomDetailsUiState(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -96,7 +96,7 @@ class StudyRoomListViewModel @Inject constructor(
         viewModelScope.launch {
 
             val result = kotlin.runCatching {
-                studyRoomListUseCase.execute(_uiState.value.timeSlot!!)
+                studyRoomListUseCase.execute(_uiState.value.timeSlot)
             }
 
             if (result.isSuccess) {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -96,7 +96,8 @@ class StudyRoomListViewModel @Inject constructor(
         viewModelScope.launch {
 
             val result = kotlin.runCatching {
-                studyRoomListUseCase.execute(_uiState.value.timeSlot!!)
+                studyRoomListUseCase.execute(
+                    _uiState.value.timeSlot!!)
             }
 
             if (result.isSuccess) {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -2,6 +2,7 @@ package team.aliens.dms_android.feature.studyroom
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import team.aliens.dms_android._base.BaseEvent
@@ -80,7 +81,7 @@ class StudyRoomListViewModel @Inject constructor(
         viewModelScope.launch {
 
             val result = kotlin.runCatching {
-                studyRoomListUseCase.execute(Unit)
+                studyRoomListUseCase.execute(_uiState.value.timeSlot!!)
             }
 
             if (result.isSuccess) {
@@ -102,10 +103,8 @@ class StudyRoomListViewModel @Inject constructor(
         viewModelScope.launch {
 
             studyRoomAvailableTimeListUseCase()
-                .onSuccess {
-                    val resultEntity = it
-
-                    _uiState.value.copy(
+                .onSuccess { resultEntity ->
+                    _uiState.value = _uiState.value.copy(
                         studyRoomAvailableTime = resultEntity.timeSlots,
                     )
                 }
@@ -116,6 +115,14 @@ class StudyRoomListViewModel @Inject constructor(
                 }
 
         }
+    }
+
+    internal fun setStudyRoomAvailableTime(
+        timeSlot: UUID,
+    ){
+        _uiState.value = _uiState.value.copy(
+            timeSlot = timeSlot,
+        )
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms_android.feature.studyroom
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
@@ -30,13 +29,11 @@ class StudyRoomListViewModel @Inject constructor(
 
     sealed class UiEvent : BaseEvent {
 
-        internal object FetchStudyRooms : UiEvent()
-
-        internal object FetchStudyRoomAvailableTimes : UiEvent()
-
-        internal data class SetStudyRoomAvailableTime(
+        data class FetchStudyRooms(
             val timeSlot: UUID,
         ) : UiEvent()
+
+        internal object FetchStudyRoomAvailableTimes : UiEvent()
 
         internal class FilterStudyRoom(
             studyRoomTime: Any?,
@@ -45,22 +42,17 @@ class StudyRoomListViewModel @Inject constructor(
 
     override val _uiState = MutableStateFlow(StudyRoomListUiState())
 
-    private var timeSlot = _uiState.value.timeSlot
-
     override fun onEvent(
         event: UiEvent,
     ) {
         when (event) {
             is UiEvent.FetchStudyRooms -> {
-                fetchStudyRoomList()
+                fetchStudyRoomList(
+                    timeSlot = event.timeSlot,
+                )
             }
             is UiEvent.FetchStudyRoomAvailableTimes -> {
                 fetchStudyRoomAvailableTimeList()
-            }
-            is UiEvent.SetStudyRoomAvailableTime -> {
-                setStudyRoomAvailableTime(
-                    timeSlot = event.timeSlot,
-                )
             }
             is UiEvent.FilterStudyRoom -> {
                 // todo
@@ -95,12 +87,14 @@ class StudyRoomListViewModel @Inject constructor(
         }
     }
 
-    private fun fetchStudyRoomList() {
+    private fun fetchStudyRoomList(
+        timeSlot: UUID,
+    ) {
         viewModelScope.launch {
 
             val result = kotlin.runCatching {
                 studyRoomListUseCase.execute(
-                    data = timeSlot!!,
+                    data = timeSlot,
                 )
             }
 
@@ -133,14 +127,6 @@ class StudyRoomListViewModel @Inject constructor(
                     )
                 }
         }
-    }
-
-    private fun setStudyRoomAvailableTime(
-        timeSlot: UUID,
-    ) {
-        _uiState.value = _uiState.value.copy(
-            timeSlot = timeSlot,
-        )
     }
 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -11,7 +11,6 @@ import team.aliens.dms_android._base.BaseViewModel
 import team.aliens.dms_android.util.extractHourFromDate
 import team.aliens.domain.exception.NotFoundException
 import team.aliens.domain.usecase.studyroom.*
-import java.lang.NullPointerException
 
 @HiltViewModel
 class StudyRoomListViewModel @Inject constructor(
@@ -108,9 +107,7 @@ class StudyRoomListViewModel @Inject constructor(
                     studyRooms = resultEntity.studyRooms.toInformation(),
                 )
             } else {
-                if (result.exceptionOrNull() != NullPointerException()) {
-                    emitErrorEventFromThrowable(result.exceptionOrNull())
-                }
+                emitErrorEventFromThrowable(result.exceptionOrNull())
             }
         }
     }
@@ -122,7 +119,6 @@ class StudyRoomListViewModel @Inject constructor(
                     _uiState.value = _uiState.value.copy(
                         studyRoomAvailableTime = resultEntity.timeSlots,
                     )
-                    fetchStudyRoomList()
                 }
                 .onFailure {
                     emitErrorEventFromThrowable(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -96,7 +96,7 @@ class StudyRoomListViewModel @Inject constructor(
         viewModelScope.launch {
 
             val result = kotlin.runCatching {
-                studyRoomListUseCase.execute(_uiState.value.timeSlot)
+                studyRoomListUseCase.execute(_uiState.value.timeSlot!!)
             }
 
             if (result.isSuccess) {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -23,8 +23,8 @@ class StudyRoomListViewModel @Inject constructor(
 ) : BaseViewModel<StudyRoomListUiState, StudyRoomListViewModel.UiEvent>() {
 
     init {
-        fetchStudyRoomList()
-        fetchApplyTime()
+        //fetchStudyRoomList()
+        //fetchApplyTime()
         fetchStudyRoomAvailableTimeList()
     }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms_android.feature.studyroom
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
@@ -84,10 +85,10 @@ class StudyRoomListViewModel @Inject constructor(
                     hasApplyTime = true,
                 )
             } else {
-
                 val exception = result.exceptionOrNull()
 
-                if (exception is NotFoundException) {
+                if (exception !is NotFoundException) {
+
                     emitErrorEventFromThrowable(exception)
                 }
             }
@@ -111,7 +112,9 @@ class StudyRoomListViewModel @Inject constructor(
                     studyRooms = resultEntity.studyRooms.toInformation(),
                 )
             } else {
-                emitErrorEventFromThrowable(result.exceptionOrNull())
+                if (result.exceptionOrNull() !is NullPointerException) {
+                    emitErrorEventFromThrowable(result.exceptionOrNull())
+                }
             }
         }
     }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -2,20 +2,16 @@ package team.aliens.dms_android.feature.studyroom
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.UUID
+import java.util.*
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import team.aliens.dms_android._base.BaseEvent
 import team.aliens.dms_android._base.BaseViewModel
 import team.aliens.dms_android.util.extractHourFromDate
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomListUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomSeatTypeUseCase
-import team.aliens.domain.usecase.studyroom.RemoteApplySeatUseCase
-import team.aliens.domain.usecase.studyroom.RemoteCancelApplySeatUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomApplicationTimeUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchCurrentStudyRoomOptionUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomAvailableTimeListUseCase
+import team.aliens.domain.exception.NotFoundException
+import team.aliens.domain.usecase.studyroom.*
+import java.lang.NullPointerException
 
 @HiltViewModel
 class StudyRoomListViewModel @Inject constructor(
@@ -40,7 +36,7 @@ class StudyRoomListViewModel @Inject constructor(
 
         internal data class SetStudyRoomAvailableTime(
             val timeSlot: UUID,
-        ): UiEvent()
+        ) : UiEvent()
 
         internal class FilterStudyRoom(
             studyRoomTime: Any?,
@@ -84,11 +80,15 @@ class StudyRoomListViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     startAt = resultEntity.startAt.extractHourFromDate(),
                     endAt = resultEntity.endAt.extractHourFromDate(),
+                    hasApplyTime = true,
                 )
             } else {
-                emitErrorEventFromThrowable(
-                    result.exceptionOrNull(),
-                )
+
+                val exception = result.exceptionOrNull()
+
+                if (exception != NotFoundException()) {
+                    emitErrorEventFromThrowable(exception)
+                }
             }
         }
     }
@@ -108,9 +108,9 @@ class StudyRoomListViewModel @Inject constructor(
                     studyRooms = resultEntity.studyRooms.toInformation(),
                 )
             } else {
-                emitErrorEventFromThrowable(
-                    result.exceptionOrNull(),
-                )
+                if (result.exceptionOrNull() != NullPointerException()) {
+                    emitErrorEventFromThrowable(result.exceptionOrNull())
+                }
             }
         }
     }
@@ -129,7 +129,6 @@ class StudyRoomListViewModel @Inject constructor(
                         throwable = it
                     )
                 }
-
         }
     }
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -44,6 +44,8 @@ class StudyRoomListViewModel @Inject constructor(
 
     override val _uiState = MutableStateFlow(StudyRoomListUiState())
 
+    private var timeSlot = _uiState.value.timeSlot
+
     override fun onEvent(
         event: UiEvent,
     ) {
@@ -85,7 +87,7 @@ class StudyRoomListViewModel @Inject constructor(
 
                 val exception = result.exceptionOrNull()
 
-                if (exception != NotFoundException()) {
+                if (exception is NotFoundException) {
                     emitErrorEventFromThrowable(exception)
                 }
             }
@@ -97,7 +99,8 @@ class StudyRoomListViewModel @Inject constructor(
 
             val result = kotlin.runCatching {
                 studyRoomListUseCase.execute(
-                    _uiState.value.timeSlot!!)
+                    data = timeSlot!!,
+                )
             }
 
             if (result.isSuccess) {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomListViewModel.kt
@@ -112,7 +112,7 @@ class StudyRoomListViewModel @Inject constructor(
         }
     }
 
-    internal fun fetchStudyRoomAvailableTimeList() {
+    private fun fetchStudyRoomAvailableTimeList() {
         viewModelScope.launch {
             studyRoomAvailableTimeListUseCase()
                 .onSuccess { resultEntity ->

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/image/ConfirmImageViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/image/ConfirmImageViewModel.kt
@@ -14,6 +14,9 @@ import team.aliens.domain.usecase.file.RemoteUploadFileUseCase
 import team.aliens.domain.usecase.students.RemoteEditProfileImageUseCase
 import java.io.File
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @HiltViewModel
 class ConfirmImageViewModel @Inject constructor(
@@ -28,6 +31,9 @@ class ConfirmImageViewModel @Inject constructor(
 
     private var _confirmImageEvent = MutableEventFlow<Event>()
     internal val confirmImageEvent = _confirmImageEvent.asEventFlow()
+
+    private var _confirmImageButtonState = MutableStateFlow(true)
+    internal val confirmImageButtonState = _confirmImageButtonState.asStateFlow()
 
     internal fun uploadImage() {
         runBlocking {
@@ -45,6 +51,7 @@ class ConfirmImageViewModel @Inject constructor(
 
 
     internal fun editProfileImage() {
+        setConfirmButtonState(false)
         viewModelScope.launch {
             kotlin.runCatching {
 
@@ -86,6 +93,14 @@ class ConfirmImageViewModel @Inject constructor(
         oldState: ConfirmImageState,
         event: ConfirmImageEvent,
     ) {
+    }
+
+    internal fun setConfirmButtonState(
+        confirmButtonState: Boolean,
+    ){
+        viewModelScope.launch(Dispatchers.Main) {
+            _confirmImageButtonState.emit(confirmButtonState)
+        }
     }
 
     sealed class Event {

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailUiState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailUiState.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms_android.viewmodel.studyroom
 
+import java.util.*
 import team.aliens.dms_android._base.BaseUiState
 import team.aliens.dms_android.util.MutableEventFlow
 import team.aliens.domain.entity.studyroom.SeatTypeEntity
@@ -7,6 +8,7 @@ import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
 
 data class StudyRoomDetailUiState(
     var studyRoomId: String = "",
+    var timeSlot: UUID? = null,
     var currentSeat: MutableEventFlow<String> = MutableEventFlow(),
     var startAt: String = "",
     var endAt: String = "",

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms_android.viewmodel.studyroom
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
@@ -167,7 +166,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
                 fetchStudyRoomDetailUseCase.execute(
-                    data = StudyRoomDetailParam(
+                    studyRoomDetailParam = StudyRoomDetailParam(
                         roomId = roomId,
                         timeSlot = timeSlot,
                     ),

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -32,7 +32,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
         class ApplySeat(
             val seat: String,
-            val timeSlot: UUID?,
+            val timeSlot: UUID,
         ) : UiEvent()
 
         object CancelApplySeat : UiEvent()
@@ -53,7 +53,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
         fetchStudyRoomDetails(
             roomId = roomId,
-            timeSlot = timeSlot,
+            timeSlot = timeSlot!!,
         )
 
         fetchApplyTime()
@@ -81,7 +81,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
     private fun applySeat(
         seatId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
@@ -94,7 +94,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
             }.onSuccess {
                 fetchStudyRoomDetails(
                     roomId = _uiState.value.studyRoomId,
-                    timeSlot = _uiState.value.timeSlot,
+                    timeSlot = _uiState.value.timeSlot!!,
                 )
             }.onFailure {
                 when (it) {
@@ -110,7 +110,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
                     is KotlinNullPointerException -> { // todo optimize code
                         fetchStudyRoomDetails(
                             roomId = _uiState.value.studyRoomId,
-                            timeSlot = _uiState.value.timeSlot,
+                            timeSlot = _uiState.value.timeSlot!!,
                         )
                     }
                 }
@@ -124,12 +124,12 @@ class StudyRoomDetailsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
                 cancelApplySeatUseCase.execute(
-                    data = _uiState.value.timeSlot
+                    data = _uiState.value.timeSlot!!
                 )
             }.onSuccess {
                 fetchStudyRoomDetails(
                     roomId = _uiState.value.studyRoomId,
-                    timeSlot = _uiState.value.timeSlot,
+                    timeSlot = _uiState.value.timeSlot!!,
                 )
             }.onFailure {
                 emitErrorEventFromThrowable(it)
@@ -162,7 +162,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
     private fun fetchStudyRoomDetails(
         roomId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -41,14 +41,17 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
     override val _uiState = MutableStateFlow(StudyRoomDetailUiState())
 
+    private var roomId = _uiState.value.studyRoomId
+    private var timeSlot = _uiState.value.timeSlot
+
     internal fun initStudyRoom(
         roomId: String,
         timeSlot: UUID?,
     ) {
         require(roomId.isNotBlank())
 
-        _uiState.value.studyRoomId = roomId
-        _uiState.value.timeSlot = timeSlot
+        this.roomId = roomId
+        this.timeSlot = timeSlot
 
         fetchStudyRoomDetails(
             roomId = roomId,
@@ -92,8 +95,8 @@ class StudyRoomDetailsViewModel @Inject constructor(
                 )
             }.onSuccess {
                 fetchStudyRoomDetails(
-                    roomId = _uiState.value.studyRoomId,
-                    timeSlot = _uiState.value.timeSlot!!,
+                    roomId = roomId,
+                    timeSlot = timeSlot,
                 )
             }.onFailure {
                 when (it) {
@@ -108,8 +111,8 @@ class StudyRoomDetailsViewModel @Inject constructor(
                     )
                     is KotlinNullPointerException -> { // todo optimize code
                         fetchStudyRoomDetails(
-                            roomId = _uiState.value.studyRoomId,
-                            timeSlot = _uiState.value.timeSlot!!,
+                            roomId = roomId,
+                            timeSlot = timeSlot,
                         )
                     }
                 }
@@ -123,12 +126,12 @@ class StudyRoomDetailsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
                 cancelApplySeatUseCase.execute(
-                    data = _uiState.value.timeSlot!!
+                    data = timeSlot!!
                 )
             }.onSuccess {
                 fetchStudyRoomDetails(
-                    roomId = _uiState.value.studyRoomId,
-                    timeSlot = _uiState.value.timeSlot!!,
+                    roomId = roomId,
+                    timeSlot = timeSlot!!,
                 )
             }.onFailure {
                 emitErrorEventFromThrowable(it)

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -2,6 +2,8 @@ package team.aliens.dms_android.viewmodel.studyroom
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.*
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -11,13 +13,10 @@ import team.aliens.dms_android.util.extractHourFromDate
 import team.aliens.domain.exception.ConflictException
 import team.aliens.domain.exception.ForbiddenException
 import team.aliens.domain.exception.UnauthorizedException
-import team.aliens.domain.usecase.studyroom.RemoteApplySeatUseCase
-import team.aliens.domain.usecase.studyroom.RemoteCancelApplySeatUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomApplicationTimeUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomDetailUseCase
-import team.aliens.domain.usecase.studyroom.RemoteFetchStudyRoomSeatTypeUseCase
+import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.StudyRoomDetailParam
+import team.aliens.domain.usecase.studyroom.*
 import team.aliens.presentation.R
-import javax.inject.Inject
 
 @HiltViewModel
 class StudyRoomDetailsViewModel @Inject constructor(
@@ -30,7 +29,10 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
     sealed class UiEvent : BaseEvent {
 
-        class ApplySeat(val seat: String) : UiEvent()
+        class ApplySeat(
+            val seat: String,
+            val timeSlot: UUID?,
+        ) : UiEvent()
 
         object CancelApplySeat : UiEvent()
 
@@ -40,13 +42,18 @@ class StudyRoomDetailsViewModel @Inject constructor(
     override val _uiState = MutableStateFlow(StudyRoomDetailUiState())
 
     internal fun initStudyRoom(
-        studyRoomId: String,
+        roomId: String,
+        timeSlot: UUID?,
     ) {
-        require(studyRoomId.isNotBlank())
+        require(roomId.isNotBlank())
 
-        _uiState.value.studyRoomId = studyRoomId
+        _uiState.value.studyRoomId = roomId
+        _uiState.value.timeSlot = timeSlot
 
-        fetchStudyRoomDetails(studyRoomId)
+        fetchStudyRoomDetails(
+            roomId = roomId,
+            timeSlot = timeSlot,
+        )
 
         fetchApplyTime()
         fetchRoomSeatType()
@@ -55,7 +62,10 @@ class StudyRoomDetailsViewModel @Inject constructor(
     override fun onEvent(event: UiEvent) {
         when (event) {
             is UiEvent.ApplySeat -> {
-                applySeat(event.seat)
+                applySeat(
+                    event.seat,
+                    event.timeSlot,
+                )
             }
             is UiEvent.CancelApplySeat -> {
                 cancelSeat()
@@ -69,16 +79,23 @@ class StudyRoomDetailsViewModel @Inject constructor(
     }
 
     private fun applySeat(
-        seat: String,
+        seatId: String,
+        timeSlot: UUID?,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
-                applySeatUseCase.execute(seat)
+                applySeatUseCase.execute(
+                    ApplyStudyRoomParam(
+                        seatId = seatId,
+                        timeSlot = timeSlot,
+                    )
+                )
             }.onSuccess {
                 fetchStudyRoomDetails(
-                    studyRoomId = _uiState.value.studyRoomId,
+                    roomId = _uiState.value.studyRoomId,
+                    timeSlot = _uiState.value.timeSlot,
                 )
-            }.recover {
+            }.onFailure {
                 when (it) {
                     is UnauthorizedException -> emitErrorEvent(
                         application.getString(R.string.NotAvailableSeat),
@@ -91,7 +108,8 @@ class StudyRoomDetailsViewModel @Inject constructor(
                     )
                     is KotlinNullPointerException -> { // todo optimize code
                         fetchStudyRoomDetails(
-                            studyRoomId = _uiState.value.studyRoomId,
+                            roomId = _uiState.value.studyRoomId,
+                            timeSlot = _uiState.value.timeSlot,
                         )
                     }
                 }
@@ -107,7 +125,8 @@ class StudyRoomDetailsViewModel @Inject constructor(
                 cancelApplySeatUseCase.execute(Unit)
             }.onSuccess {
                 fetchStudyRoomDetails(
-                    studyRoomId = _uiState.value.studyRoomId,
+                    roomId = _uiState.value.studyRoomId,
+                    timeSlot = _uiState.value.timeSlot,
                 )
             }.onFailure {
                 emitErrorEventFromThrowable(it)
@@ -139,11 +158,17 @@ class StudyRoomDetailsViewModel @Inject constructor(
     }
 
     private fun fetchStudyRoomDetails(
-        studyRoomId: String,
+        roomId: String,
+        timeSlot: UUID?,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
-                fetchStudyRoomDetailUseCase.execute(studyRoomId)
+                fetchStudyRoomDetailUseCase.execute(
+                    data = StudyRoomDetailParam(
+                        roomId = roomId,
+                        timeSlot = timeSlot,
+                    ),
+                )
             }.onSuccess {
                 _uiState.value = _uiState.value.copy(
                     studyRoomDetails = it,
@@ -155,7 +180,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
     }
 
     private fun fetchRoomSeatType() {
-        viewModelScope.launch(Dispatchers.IO){
+        viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
                 fetchSeatTypeUseCase.execute(Unit)
             }.onSuccess {

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -46,7 +46,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
     internal fun initStudyRoom(
         roomId: String,
-        timeSlot: UUID?,
+        timeSlot: UUID,
     ) {
         require(roomId.isNotBlank())
 
@@ -55,7 +55,7 @@ class StudyRoomDetailsViewModel @Inject constructor(
 
         fetchStudyRoomDetails(
             roomId = roomId,
-            timeSlot = timeSlot!!,
+            timeSlot = timeSlot,
         )
 
         fetchApplyTime()

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms_android.viewmodel.studyroom
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
@@ -122,7 +123,9 @@ class StudyRoomDetailsViewModel @Inject constructor(
     private fun cancelSeat() {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
-                cancelApplySeatUseCase.execute(Unit)
+                cancelApplySeatUseCase.execute(
+                    data = _uiState.value.timeSlot
+                )
             }.onSuccess {
                 fetchStudyRoomDetails(
                     roomId = _uiState.value.studyRoomId,

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -203,4 +203,6 @@
     <string name="SendIdToEmail">%s 으로 아이디가 전송되었어요.</string>
     <string name="NeedAccount">위 정보로 가입된 계정이 없습니다.</string>
     <string name="MissMatchAccountInfo">학생 정보가 일치하지 않습니다.</string>
+
+    <string name="study_room_apply_time">자습실 신청 가능 시간 : %s</string>
 </resources>


### PR DESCRIPTION
## 개요
> 자습실 이용시간에 따른 목록 조회 / 신청 / 취소 / 상세보기 로직을 리팩토링 했습니다

## 작업사항
- 조회 / 신청 / 취소 / 상세보기 로직에 uuid 파라미터 추가
- 이용 시간 목록 조회 로직 및 뷰 리팩토링
- 프로필 이미지 변경 로직 중복 요청 방지를 위한 버튼 비활성화 로직 구현

## 추가 로 할 말
- UUID 에 null 처리는 이용 시간이 설정되어 있지 않은 학교의 경우 이용 시간 값을 null 로 보내야 하기 때문입니다.
- 자습실 상세보기에서 자리 컬러가 검정색인 경우 글자가 보이지 않습니다 (배경 색과 동일해서 그런걸로 추정)