### PR TITLE
🔀 :: (#367) 로그인 후 처음 화면 진입시 비정상 종료 해결

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/common/CompositionLocal.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/common/CompositionLocal.kt
@@ -3,5 +3,5 @@ package team.aliens.dms_android.common
 import androidx.compose.runtime.staticCompositionLocalOf
 
 val LocalAvailableFeatures = staticCompositionLocalOf {
-    emptyMap<String, Boolean>()
+    mutableMapOf<String, Boolean>()
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/MainActivity.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/MainActivity.kt
@@ -22,16 +22,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
             val secondIntent = intent
             val route = secondIntent.getStringExtra("route")
 
-            var availableFeatures = staticCompositionLocalOf {
-                emptyMap<String, Boolean>()
-            }
-
             if (route != null) {
                 DormTheme(
                     darkTheme = isSystemInDarkTheme(),
                 ) {
-                    availableFeatures = staticCompositionLocalOf {
-                        mapOf(
+                    val availableFeatures = staticCompositionLocalOf {
+                        mutableMapOf(
                             Extra.isMealServiceEnabled to intent.getBooleanExtra(
                                 Extra.isMealServiceEnabled, false,
                             ),

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -65,19 +65,24 @@ fun LoginScreen(
     val onSignInSuccess = { visibleEntity: UserVisibleInformEntity ->
         feature.run {
             set(
-                Extra.isMealServiceEnabled, visibleEntity.mealService,
+                Extra.isMealServiceEnabled,
+                visibleEntity.mealService,
             )
             set(
-                Extra.isNoticeServiceEnabled, visibleEntity.noticeService
+                Extra.isNoticeServiceEnabled,
+                visibleEntity.noticeService,
             )
             set(
-                Extra.isPointServiceEnabled, visibleEntity.pointService
+                Extra.isPointServiceEnabled,
+                visibleEntity.pointService,
             )
             set(
-                Extra.isStudyRoomEnabled, visibleEntity.studyRoomService
+                Extra.isStudyRoomEnabled,
+                visibleEntity.studyRoomService,
             )
             set(
-                Extra.isRemainServiceEnabled, visibleEntity.remainService
+                Extra.isRemainServiceEnabled,
+                visibleEntity.remainService,
             )
         }
     }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/auth/login/LoginScreen.kt
@@ -30,11 +30,13 @@ import team.aliens.design_system.theme.DormTheme
 import team.aliens.design_system.toast.rememberToast
 import team.aliens.design_system.typography.Body2
 import team.aliens.design_system.typography.Caption
+import team.aliens.dms_android.common.LocalAvailableFeatures
 import team.aliens.dms_android.component.AppLogo
 import team.aliens.dms_android.constans.Extra
 import team.aliens.dms_android.feature.navigator.NavigationRoute
 import team.aliens.dms_android.viewmodel.auth.login.SignInViewModel
 import team.aliens.dms_android.viewmodel.auth.login.SignInViewModel.Event
+import team.aliens.local_domain.entity.notice.UserVisibleInformEntity
 import team.aliens.presentation.R
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -58,32 +60,33 @@ fun LoginScreen(
 
     signInButtonState = signInViewModel.signInButtonState.collectAsState().value
 
+    val feature = LocalAvailableFeatures.current
+
+    val onSignInSuccess = { visibleEntity: UserVisibleInformEntity ->
+        feature.run {
+            set(
+                Extra.isMealServiceEnabled, visibleEntity.mealService,
+            )
+            set(
+                Extra.isNoticeServiceEnabled, visibleEntity.noticeService
+            )
+            set(
+                Extra.isPointServiceEnabled, visibleEntity.pointService
+            )
+            set(
+                Extra.isStudyRoomEnabled, visibleEntity.studyRoomService
+            )
+            set(
+                Extra.isRemainServiceEnabled, visibleEntity.remainService
+            )
+        }
+    }
+
     LaunchedEffect(Unit) {
         signInViewModel.signInViewEffect.collect { event ->
             when (event) {
                 is Event.NavigateToHome -> {
-                    navController.currentBackStackEntry?.arguments?.apply {
-                        putBoolean(
-                            Extra.isMealServiceEnabled,
-                            event.userVisibleInformEntity.mealService
-                        )
-                        putBoolean(
-                            Extra.isNoticeServiceEnabled,
-                            event.userVisibleInformEntity.noticeService
-                        )
-                        putBoolean(
-                            Extra.isPointServiceEnabled,
-                            event.userVisibleInformEntity.pointService
-                        )
-                        putBoolean(
-                            Extra.isStudyRoomEnabled,
-                            event.userVisibleInformEntity.studyRoomService
-                        )
-                        putBoolean(
-                            Extra.isRemainServiceEnabled,
-                            event.userVisibleInformEntity.remainService
-                        )
-                    }
+                    onSignInSuccess(event.userVisibleInformEntity)
                     navController.navigate(NavigationRoute.Main) {
                         popUpTo(NavigationRoute.Login) {
                             inclusive = true
@@ -148,8 +151,7 @@ fun LoginScreen(
             rippleEnabled = false,
         ) {
             focusManager.clearFocus()
-        }
-    ) {
+        }) {
 
         Space(space = 92.dp)
 

--- a/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
@@ -53,7 +53,7 @@ fun MyPageScreen(
 
     val context = LocalContext.current
 
-    val isPointServiceEnabled = false
+    val isPointServiceEnabled = LocalAvailableFeatures.current[Extra.isPointServiceEnabled]
 
     var myPageState by remember {
         mutableStateOf(MyPageEntity())

--- a/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
@@ -53,7 +53,7 @@ fun MyPageScreen(
 
     val context = LocalContext.current
 
-    val isPointServiceEnabled = false//LocalAvailableFeatures.current[Extra.isPointServiceEnabled]
+    val isPointServiceEnabled = false
 
     var myPageState by remember {
         mutableStateOf(MyPageEntity())

--- a/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/mypage/MyPageScreen.kt
@@ -5,25 +5,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.ScaffoldState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,7 +53,7 @@ fun MyPageScreen(
 
     val context = LocalContext.current
 
-    val isPointServiceEnabled = LocalAvailableFeatures.current[Extra.isPointServiceEnabled]
+    val isPointServiceEnabled = false//LocalAvailableFeatures.current[Extra.isPointServiceEnabled]
 
     var myPageState by remember {
         mutableStateOf(MyPageEntity())
@@ -147,6 +134,10 @@ fun MyPageScreen(
 
     val onSetProfileDialogDismiss = {
         setProfileDialogState = false
+    }
+
+    val onPasswordChangeClicked = {
+        navController.navigate(NavigationRoute.ComparePassword)
     }
 
     if (setProfileDialogState) {
@@ -439,9 +430,7 @@ fun MyPageScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable {
-                                navController.navigate(NavigationRoute.ComparePassword)
-                            }
+                            .clickable { onPasswordChangeClicked() }
                             .padding(
                                 vertical = 14.dp,
                                 horizontal = 16.dp,
@@ -471,7 +460,7 @@ fun MyPageScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                onSignOutButtonClick()
+                                onPasswordChangeClicked()
                             }
                             .padding(
                                 vertical = 14.dp,

--- a/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/navigator/DmsApp.kt
@@ -44,9 +44,9 @@ fun DmsApp(
     val applicationServiceEnabled =
         LocalAvailableFeatures.current[Extra.isStudyRoomEnabled]!! || LocalAvailableFeatures.current[Extra.isRemainServiceEnabled]!!
 
-    if (!applicationServiceEnabled) {
-        with(NavigationItemsWrapper.navigationItems){
-            removeAt(indexOf(BottomNavigationItem.Application))
+    val navigationItems = NavigationItemsWrapper.navigationItems.also {
+        if (!applicationServiceEnabled) {
+            it.remove(BottomNavigationItem.Application)
         }
     }
 
@@ -58,6 +58,7 @@ fun DmsApp(
                 BottomNavBar(
                     navController = navHostController,
                     navBackStackEntry = navBackStackEntry,
+                    navigationItems = navigationItems,
                 )
             }
         },
@@ -115,9 +116,10 @@ private object NavigationItemsWrapper {
 }
 
 @Composable
-fun BottomNavBar(
+private fun BottomNavBar(
     navController: NavHostController,
     navBackStackEntry: NavBackStackEntry?,
+    navigationItems: List<BottomNavigationItem>,
 ) {
 
     val currentDestination = navBackStackEntry?.destination?.route
@@ -136,7 +138,7 @@ fun BottomNavBar(
             shadowElevation = 20f
         },
     ) {
-        NavigationItemsWrapper.navigationItems.forEach { navigationItem ->
+        navigationItems.forEach { navigationItem ->
 
             val selected = navigationItem.route == currentDestination
 


### PR DESCRIPTION
## 개요
> 로그인 화면에서 메인 화면으로 진입할 때, 사용 가능 기능에 따라 화면이 제대로 구성되지 않는 버그를 고칩니다.

## 작업사항
- LoginScreen, DmsApp에 잘못된 composition local을 수정하였습니다

## 추가 로 할 말
pr 메시지 잘 쓰겠습니다.. 