### PR TITLE
🔀 :: (#365) ci에 DEV_BASE_URL 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
       - name: Generate local.properties
         run: |
           echo $PROD_BASE_URL >> ./local.properties
-          cat 
+          echo $DEV_BASE_URL >> ./local.properties
+          cat
         env:
             PROD_BASE_URL: ${{secrets.PROD_BASE_URL}}
+            DEV_BASE_URL: ${{secrets.DEV_BASE_URL}}
       - name: Build with Gradle
         run: ./gradlew build
       - name: Run test


### PR DESCRIPTION
## 개요
> ci에 DEV_BASE_URL을 추가합니다

## 작업사항
- ci 문서에 DEV_BASE_URL 추가 및 github secret에 존재하는 URL 참조

## 추가 로 할 말
