### PR TITLE
🔀 :: (#374) 회원가입 이메일 요청 중복 처리 예외 버그 수정

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/_base/BaseViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/_base/BaseViewModel.kt
@@ -62,6 +62,7 @@ abstract class BaseViewModel<S : BaseUiState, E : BaseEvent> : ViewModel() {
             is UnauthorizedException -> ErrorEvent.Unauthorized
             is NoInternetException -> ErrorEvent.NoInternet
             is TooManyRequestException -> ErrorEvent.TooManyRequests
+            is TimeoutException -> ErrorEvent.TimeOut
             is ServerException -> ErrorEvent.InternalServerError
             else -> ErrorEvent.Unknown
         }
@@ -79,6 +80,7 @@ abstract class BaseViewModel<S : BaseUiState, E : BaseEvent> : ViewModel() {
                 ErrorEvent.TooManyRequests -> R.string.TooManyRequest
                 ErrorEvent.Unauthorized -> R.string.UnAuthorized
                 ErrorEvent.Unknown -> R.string.UnKnownException
+                ErrorEvent.TimeOut -> R.string.error_timeout
             },
         )
     }

--- a/presentation/src/main/java/team/aliens/dms_android/_base/ErrorEvent.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/_base/ErrorEvent.kt
@@ -14,5 +14,7 @@ sealed class ErrorEvent {
 
     object InternalServerError : ErrorEvent()
 
+    object TimeOut : ErrorEvent()
+
     object Unknown : ErrorEvent()
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailScreen.kt
@@ -112,21 +112,6 @@ fun SignUpEmailScreen(
                 }
                 is RegisterEmailEvent.TooManyRequestsException -> {
                     toast(context.getString(R.string.ChangeEmail))
-                    navController.currentBackStackEntry?.arguments?.run {
-                        putString(
-                            "schoolCode",
-                            navController.previousBackStackEntry?.arguments?.getString("schoolCode")
-                        )
-                        putString(
-                            "schoolId",
-                            navController.previousBackStackEntry?.arguments?.getString("schoolId")
-                        )
-                        putString(
-                            "schoolAnswer",
-                            navController.previousBackStackEntry?.arguments?.getString("schoolAnswer")
-                        )
-                        putString("email", email)
-                    }
                 }
                 else -> toast(
                     getStringFromEvent(

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
@@ -137,6 +137,7 @@ fun SignUpEmailVerifyScreen(
                                 )
                             }
                         }
+                        navigate(NavigationRoute.SignUpId)
                     }
                 }
                 is RegisterEmailEvent.SendEmailSuccess -> {

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
@@ -269,7 +269,7 @@ fun SignUpEmailVerifyScreen(
                 text = time,
                 color = DormTheme.colors.primary,
             )
-            RatioSpace(height = 0.85f)
+            RatioSpace(height = 0.649f)
             ButtonText(
                 modifier = Modifier.dormClickable(
                     rippleEnabled = false,

--- a/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/register/ui/email/SignUpEmailVerifyScreen.kt
@@ -114,7 +114,7 @@ fun SignUpEmailVerifyScreen(
                 is RegisterEmailEvent.CheckEmailSuccess -> {
                     with(navController) {
                         currentBackStackEntry?.arguments?.run {
-                            currentBackStackEntry?.arguments?.let {
+                            previousBackStackEntry?.arguments?.let {
                                 putString(
                                     "schoolCode",
                                     it.getString("schoolCode"),

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/email/RegisterEmailViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/auth/register/email/RegisterEmailViewModel.kt
@@ -3,6 +3,7 @@ package team.aliens.dms_android.viewmodel.auth.register.email
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import team.aliens.dms_android.feature.register.event.email.RegisterEmailEvent
 import team.aliens.dms_android.util.MutableEventFlow
@@ -14,7 +15,6 @@ import team.aliens.domain.param.RequestEmailCodeParam
 import team.aliens.domain.usecase.students.DuplicateCheckEmailUseCase
 import team.aliens.domain.usecase.user.RemoteCheckEmailUseCase
 import team.aliens.domain.usecase.user.RemoteRequestEmailCodeUseCase
-import javax.inject.Inject
 
 @HiltViewModel
 class RegisterEmailViewModel @Inject constructor(
@@ -44,7 +44,6 @@ class RegisterEmailViewModel @Inject constructor(
                 when (it) {
                     is BadRequestException -> event(RegisterEmailEvent.BadRequestException)
                     is NotFoundException -> event(RegisterEmailEvent.CheckEmailNotFound)
-                    is ConflictException -> event(RegisterEmailEvent.ConflictException)
                     is TooManyRequestException -> event(RegisterEmailEvent.TooManyRequestsException)
                     is ServerException -> event(RegisterEmailEvent.InternalServerException)
                     else -> event(RegisterEmailEvent.UnKnownException)
@@ -74,7 +73,6 @@ class RegisterEmailViewModel @Inject constructor(
                     is BadRequestException -> event(RegisterEmailEvent.BadRequestException)
                     is UnauthorizedException -> event(RegisterEmailEvent.CheckEmailUnauthorized)
                     is NotFoundException -> event(RegisterEmailEvent.CheckEmailNotFound)
-                    is ConflictException -> event(RegisterEmailEvent.ConflictException)
                     is TooManyRequestException -> event(RegisterEmailEvent.TooManyRequestsException)
                     is ServerException -> event(RegisterEmailEvent.InternalServerException)
                     else -> event(RegisterEmailEvent.InternalServerException)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <string name="error_no_internet">네트워크 연결이 원활하지 않습니다</string>
     <string name="error_internal_server">서버와의 통신에서 오류가 발생하였습니다</string>
     <string name="error_unknown">알 수 없는 에러가 발생하였습니다</string>
+    <string name="error_timeout">요청 시간이 초과되었습니다</string>
 
     <!--sign in-->
     <string name="sign_in">로그인</string>


### PR DESCRIPTION
## 개요
> 회원가입 이메일 인증 과정에서 발생하는 예외 처리 및 잔버그를 수정했습니다.

## 작업사항
- currentBackStackEntry 중복 선언 수정
- requestEmailCode / checkEmailCode 함수에서 Conflict 분기 처리문 제거
- baseviewmodel timeoutexception 예외 처리 추가
- 인증코드 입력 화면 버튼 간격 버그 수정

## 추가 로 할 말
