### PR TITLE
🔀 :: (#376) 자습실 자리 취소 시 전체 취소 오류 수정

### DIFF
--- a/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
+++ b/data/src/main/java/team/aliens/data/remote/api/StudyRoomApi.kt
@@ -28,6 +28,7 @@ interface StudyRoomApi {
 
     @DELETE(DmsUrl.StudyRoom.CancelApply)
     suspend fun cancelApplySeat(
+        @Path("seat-id") seatId: String,
         @Query("time_slot") timeSlot: UUID,
     ): Response<Unit>
 

--- a/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/declaration/RemoteStudyRoomDataSource.kt
@@ -17,6 +17,7 @@ interface RemoteStudyRoomDataSource {
     suspend fun fetchApplySeatTime(): ApplySeatTimeResponse
 
     suspend fun cancelApplySeat(
+        seatId: String,
         timeSlot: UUID,
     )
 

--- a/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
+++ b/data/src/main/java/team/aliens/data/remote/datasource/implementation/RemoteStudyRoomDataSourceImpl.kt
@@ -29,11 +29,13 @@ class RemoteStudyRoomDataSourceImpl @Inject constructor(
         sendHttpRequest(httpRequest = suspend { studyRoomApi.fetchApplySeatTime() })
 
     override suspend fun cancelApplySeat(
+        seatId: String,
         timeSlot: UUID,
     ) {
         sendHttpRequest(
             httpRequest = suspend {
                 studyRoomApi.cancelApplySeat(
+                    seatId = seatId,
                     timeSlot = timeSlot,
                 )
             },

--- a/data/src/main/java/team/aliens/data/remote/url/DmsUrl.kt
+++ b/data/src/main/java/team/aliens/data/remote/url/DmsUrl.kt
@@ -53,7 +53,7 @@ object DmsUrl {
     object StudyRoom {
         const val Apply = "$studyRoom/seats/{seat-id}"
         const val fetchApplyTime = "$studyRoom/available-time"
-        const val CancelApply = "$studyRoom/seats"
+        const val CancelApply = "$studyRoom/seats/{seat-id}"
         const val StudyRoomList = "$studyRoom/list/students"
         const val StudyRoomType = "$studyRoom/types"
         const val StudyRoomDetail = "$studyRoom/{study-room-id}/students"

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -16,6 +16,7 @@ import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
 import team.aliens.domain.entity.studyroom.StudyRoomListEntity
 import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.CancelStudyRoomParam
 import team.aliens.domain.param.StudyRoomDetailParam
 import team.aliens.domain.repository.StudyRoomRepository
 
@@ -36,12 +37,11 @@ class StudyRoomRepositoryImpl @Inject constructor(
         remoteStudyRoomDataSource.fetchApplySeatTime().toEntity()
 
     override suspend fun cancelApplySeat(
-        seatId: String,
-        timeSlot: UUID,
+        cancelStudyRoomParam: CancelStudyRoomParam,
     ) {
         remoteStudyRoomDataSource.cancelApplySeat(
-            seatId = seatId,
-            timeSlot = timeSlot,
+            seatId = cancelStudyRoomParam.seatId,
+            timeSlot = cancelStudyRoomParam.timeSlot,
         )
     }
 

--- a/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
+++ b/data/src/main/java/team/aliens/data/repository/StudyRoomRepositoryImpl.kt
@@ -36,9 +36,11 @@ class StudyRoomRepositoryImpl @Inject constructor(
         remoteStudyRoomDataSource.fetchApplySeatTime().toEntity()
 
     override suspend fun cancelApplySeat(
+        seatId: String,
         timeSlot: UUID,
     ) {
         remoteStudyRoomDataSource.cancelApplySeat(
+            seatId = seatId,
             timeSlot = timeSlot,
         )
     }

--- a/domain/src/main/java/team/aliens/domain/param/CancelStudyRoomParam.kt
+++ b/domain/src/main/java/team/aliens/domain/param/CancelStudyRoomParam.kt
@@ -1,0 +1,8 @@
+package team.aliens.domain.param
+
+import java.util.*
+
+data class CancelStudyRoomParam(
+    val seatId: String,
+    val timeSlot: UUID,
+)

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -17,6 +17,7 @@ interface StudyRoomRepository {
     suspend fun fetchApplySeatTime(): ApplySeatTimeEntity
 
     suspend fun cancelApplySeat(
+        seatId: String,
         timeSlot: UUID,
     )
 

--- a/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
+++ b/domain/src/main/java/team/aliens/domain/repository/StudyRoomRepository.kt
@@ -8,17 +8,19 @@ import team.aliens.domain.entity.studyroom.StudyRoomAvailableTimeListEntity
 import team.aliens.domain.entity.studyroom.StudyRoomDetailEntity
 import team.aliens.domain.entity.studyroom.StudyRoomListEntity
 import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.CancelStudyRoomParam
 import team.aliens.domain.param.StudyRoomDetailParam
 
 interface StudyRoomRepository {
 
-    suspend fun applySeat(applyStudyRoomParam: ApplyStudyRoomParam)
+    suspend fun applySeat(
+        applyStudyRoomParam: ApplyStudyRoomParam,
+    )
 
     suspend fun fetchApplySeatTime(): ApplySeatTimeEntity
 
     suspend fun cancelApplySeat(
-        seatId: String,
-        timeSlot: UUID,
+        cancelStudyRoomParam: CancelStudyRoomParam,
     )
 
     suspend fun fetchStudyRoomList(

--- a/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
+++ b/domain/src/main/java/team/aliens/domain/usecase/studyroom/RemoteCancelApplySeatUseCase.kt
@@ -1,5 +1,6 @@
 package team.aliens.domain.usecase.studyroom
 
+import team.aliens.domain.param.CancelStudyRoomParam
 import java.util.UUID
 import team.aliens.domain.repository.StudyRoomRepository
 import team.aliens.domain.usecase.UseCase
@@ -7,10 +8,10 @@ import javax.inject.Inject
 
 class RemoteCancelApplySeatUseCase @Inject constructor(
     private val studyRoomRepository: StudyRoomRepository,
-) : UseCase<UUID, Unit>() {
-    override suspend fun execute(data: UUID) {
+) : UseCase<CancelStudyRoomParam, Unit>() {
+    override suspend fun execute(cancelStudyRoomParam: CancelStudyRoomParam) {
         studyRoomRepository.cancelApplySeat(
-            timeSlot = data,
+            cancelStudyRoomParam = cancelStudyRoomParam,
         )
     }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/studyroom/StudyRoomDetailScreen.kt
@@ -169,7 +169,10 @@ fun StudyRoomDetailScreen(
                     color = DormButtonColor.Gray,
                 ) {
                     studyRoomDetailsViewModel.onEvent(
-                        event = StudyRoomDetailsViewModel.UiEvent.CancelApplySeat,
+                        event = StudyRoomDetailsViewModel.UiEvent.CancelApplySeat(
+                            seatId = currentSeat,
+                            timeSlot = timeSlot,
+                        ),
                     )
                 }
 

--- a/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/viewmodel/studyroom/StudyRoomDetailsViewModel.kt
@@ -15,6 +15,7 @@ import team.aliens.domain.exception.ForbiddenException
 import team.aliens.domain.exception.NotFoundException
 import team.aliens.domain.exception.UnauthorizedException
 import team.aliens.domain.param.ApplyStudyRoomParam
+import team.aliens.domain.param.CancelStudyRoomParam
 import team.aliens.domain.param.StudyRoomDetailParam
 import team.aliens.domain.usecase.studyroom.*
 import team.aliens.presentation.R
@@ -35,7 +36,10 @@ class StudyRoomDetailsViewModel @Inject constructor(
             val timeSlot: UUID,
         ) : UiEvent()
 
-        object CancelApplySeat : UiEvent()
+        class CancelApplySeat(
+            val seatId: String,
+            val timeSlot: UUID,
+        ) : UiEvent()
 
         class ChangeSelectedSeat(val seat: String) : UiEvent()
     }
@@ -72,7 +76,10 @@ class StudyRoomDetailsViewModel @Inject constructor(
                 )
             }
             is UiEvent.CancelApplySeat -> {
-                cancelSeat()
+                cancelSeat(
+                    seatId = event.seatId,
+                    timeSlot = event.timeSlot,
+                )
             }
             is UiEvent.ChangeSelectedSeat -> {
                 changeSelectedSeat(
@@ -127,16 +134,22 @@ class StudyRoomDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun cancelSeat() {
+    private fun cancelSeat(
+        seatId: String,
+        timeSlot: UUID,
+    ) {
         viewModelScope.launch(Dispatchers.IO) {
             kotlin.runCatching {
                 cancelApplySeatUseCase.execute(
-                    data = timeSlot!!
+                    CancelStudyRoomParam(
+                        seatId = seatId,
+                        timeSlot = timeSlot,
+                    ),
                 )
             }.onSuccess {
                 fetchStudyRoomDetails(
                     roomId = roomId,
-                    timeSlot = timeSlot!!,
+                    timeSlot = timeSlot,
                 )
             }.onFailure {
                 emitErrorEventFromThrowable(it)


### PR DESCRIPTION
## 개요
> 자습실 자리 취소 시 전체 취소 오류가 뜨는 것을 수정했습니다.

## 작업사항
- CancelStudyRoomParam을 추가하였습니다
- 서버에서 추가된 path를 추가하였습니다.
- 자습실 자리 취소 비즈니스 로직을 추가하였습니다. 

## 추가 로 할 말
