### PR TITLE
🔀 :: (#406) dmsappstate 구현

### DIFF
--- a/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
@@ -4,7 +4,8 @@ import androidx.compose.material.ScaffoldState
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavController
@@ -32,10 +33,17 @@ class DmsAppState(
     private val coroutineScope: CoroutineScope,
 ) {
 
+    @Stable
+    val dialogState
+        @Composable get() = remember { mutableStateOf(false) }
+
+    @Stable
+    val currentDestination = navController.currentDestination?.route
+
     internal fun showToast(
         message: String,
         toastType: ToastType,
-    ){
+    ) {
         coroutineScope.launch {
             snackbarHostState.showSnackbar(
                 message = message,
@@ -48,5 +56,12 @@ class DmsAppState(
         route: String,
     ) {
         navController.navigate(route)
+    }
+
+    @Composable
+    internal fun setDialogState(
+        dialogState: Boolean,
+    ) {
+        this.dialogState.value = dialogState
     }
 }

--- a/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import team.aliens.design_system.toast.ToastType
 
 @Composable
-fun rememberDmsAppState(
+internal fun rememberDmsAppState(
     scaffoldState: ScaffoldState = rememberScaffoldState(),
     navController: NavController = rememberNavController(),
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
@@ -27,7 +27,7 @@ fun rememberDmsAppState(
     )
 }
 
-class DmsAppState(
+internal class DmsAppState(
     private val snackbarHostState: SnackbarHostState,
     private val navController: NavController,
     private val coroutineScope: CoroutineScope,

--- a/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
@@ -1,0 +1,52 @@
+package team.aliens.dms_android.feature.application
+
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import team.aliens.design_system.toast.ToastType
+
+@Composable
+fun rememberDmsAppState(
+    scaffoldState: ScaffoldState = rememberScaffoldState(),
+    navController: NavController = rememberNavController(),
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+) = remember {
+    DmsAppState(
+        snackbarHostState = scaffoldState.snackbarHostState,
+        navController = navController,
+        coroutineScope = coroutineScope,
+    )
+}
+
+class DmsAppState(
+    private val snackbarHostState: SnackbarHostState,
+    private val navController: NavController,
+    private val coroutineScope: CoroutineScope,
+) {
+
+    internal fun showToast(
+        message: String,
+        toastType: ToastType,
+    ){
+        coroutineScope.launch {
+            snackbarHostState.showSnackbar(
+                message = message,
+                actionLabel = toastType.toString(),
+            )
+        }
+    }
+
+    internal fun navigateToRoute(
+        route: String,
+    ) {
+        navController.navigate(route)
+    }
+}

--- a/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
+++ b/presentation/src/main/java/team/aliens/dms_android/feature/application/DmsAppState.kt
@@ -1,9 +1,9 @@
 package team.aliens.dms_android.feature.application
 
 import androidx.compose.material.ScaffoldState
-import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -11,57 +11,49 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import team.aliens.design_system.toast.ToastType
 
 @Composable
 internal fun rememberDmsAppState(
     scaffoldState: ScaffoldState = rememberScaffoldState(),
     navController: NavController = rememberNavController(),
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    bottomSheetState: MutableState<Boolean> = mutableStateOf(false),
 ) = remember {
     DmsAppState(
-        snackbarHostState = scaffoldState.snackbarHostState,
+        scaffoldState = scaffoldState,
         navController = navController,
         coroutineScope = coroutineScope,
     )
 }
 
 internal class DmsAppState(
-    private val snackbarHostState: SnackbarHostState,
-    private val navController: NavController,
-    private val coroutineScope: CoroutineScope,
+    val scaffoldState: ScaffoldState,
+    val navController: NavController,
+    coroutineScope: CoroutineScope,
 ) {
-
-    @Stable
-    val dialogState
-        @Composable get() = remember { mutableStateOf(false) }
 
     @Stable
     val currentDestination = navController.currentDestination?.route
 
-    internal fun showToast(
-        message: String,
-        toastType: ToastType,
-    ) {
+    /*init{
         coroutineScope.launch {
-            snackbarHostState.showSnackbar(
+            scaffoldState.snackbarHostState.showSnackbar(
                 message = message,
                 actionLabel = toastType.toString(),
             )
         }
     }
 
-    internal fun navigateToRoute(
+    fun showToast(
+        message: String,
+        toastType: ToastType,
+    ) {
+
+    }*/
+
+    fun navigateToRoute(
         route: String,
     ) {
         navController.navigate(route)
-    }
-
-    @Composable
-    internal fun setDialogState(
-        dialogState: Boolean,
-    ) {
-        this.dialogState.value = dialogState
     }
 }


### PR DESCRIPTION
## 개요
> 앱 전역 상태 관리를 위한 DmsAppState 및 rememberDmsAppState() 를 구현하였습니다.

## 작업사항
- rememberDmsAppState() 구현
- 내부 showToast() 및 navigateToRoute() 구현
- 내부 setDialogState() 구현

## 추가 로 할 말
추가로 bottomSheetDialog 의 전역 관리가 필요할 것 같습니다
