### PR TITLE
🔀 :: (#468) 기기에-따라-bottom-navigation의-text가-깨지는-버그-수정

### DIFF
--- a/design-system/src/main/java/team/aliens/design_system/typography/typography.kt
+++ b/design-system/src/main/java/team/aliens/design_system/typography/typography.kt
@@ -8,12 +8,14 @@ import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import team.aliens.design_system.R
 import team.aliens.design_system.annotation.DormDeprecated
@@ -168,13 +170,17 @@ object DormTypography {
     )
 
     @Stable
-    val bottomNavItemLabel = TextStyle(
-        fontFamily = NotoSansFamily,
-        fontWeight = FontWeight.Bold,
-        fontSize = 3.em,
-        lineHeight = 16.sp,
-    )
+    val bottomNavItemLabel: TextStyle
+        @Composable inline get() = TextStyle(
+            fontFamily = NotoSansFamily,
+            fontWeight = FontWeight.Bold,
+            fontSize = 12.dp.toSp(),
+            lineHeight = 16.sp,
+        )
 }
+
+@Composable
+fun Dp.toSp() = with(LocalDensity.current) { this@toSp.toSp() }
 
 @DormDeprecated
 @Composable


### PR DESCRIPTION
## 개요
> 기기에 따라 bottom navigation의 text가 깨지는 현상을 수정합니다

## 작업사항
- typography 글씨 크기 계산 로직 구현

## 추가 로 할 말
