### PR TITLE
🔀 :: (#671) 상벌점 카드 클릭 시 상벌점 페이지 버그

### DIFF
--- a/feature/src/main/java/team/aliens/dms/android/feature/point/PointHistoryViewModel.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/point/PointHistoryViewModel.kt
@@ -38,7 +38,7 @@ internal class PointHistoryViewModel @Inject constructor(
     internal fun fetchPoints(pointType: PointType) {
         viewModelScope.launch(Dispatchers.IO) {
             runCatching {
-                pointRepository.fetchPoints(type = pointType)
+                pointRepository.fetchPoints(type = PointType.ALL)
             }.onSuccess { pointStatus ->
                 this@PointHistoryViewModel.allPoints = pointStatus.points
                 this@PointHistoryViewModel.scoreOfAllPoints = pointStatus.totalPoints


### PR DESCRIPTION
## 개요
>상벌점 카드 클릭 시 상벌점 페이지 이동 하였을때 태그를 바꾸면 데이터를 불러오지 못함

## 작업사항
- api 호출하는 pointType을 파라미터로 받아오는 값을 PointType.ALL로 수정하여 전체 데이터를 불러와서 처리하도록 바꿈

## 추가 로 할 말
