### PR TITLE
🔀 :: (#757) 이메일 인증번호 보내기 버그

### DIFF
--- a/feature/src/main/java/team/aliens/dms/android/feature/resetpassword/AccountVerificationScreen.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/resetpassword/AccountVerificationScreen.kt
@@ -79,6 +79,10 @@ fun AccountVerificationScreen(
                 message = context.getString(R.string.reset_password_account_verification_account_id_does_not_exist),
             )
 
+            ResetPasswordSideEffect.EmailVerificationTooManyRequest -> toast.showErrorToast(
+                message = context.getString(R.string.reset_password_account_verification_error_too_many_request)
+            )
+
             ResetPasswordSideEffect.SendEmailVerificationCodeSuccess -> navigator.openResetPasswordEnterEmailVerificationCode()
 
             else -> { /* explicit blank */

--- a/feature/src/main/java/team/aliens/dms/android/feature/resetpassword/ResetPasswordViewModel.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/resetpassword/ResetPasswordViewModel.kt
@@ -11,6 +11,7 @@ import team.aliens.dms.android.core.ui.mvi.UiState
 import team.aliens.dms.android.data.auth.model.EmailVerificationType
 import team.aliens.dms.android.data.auth.repository.AuthRepository
 import team.aliens.dms.android.data.student.repository.StudentRepository
+import team.aliens.dms.android.feature.signup.SignUpSideEffect
 import team.aliens.dms.android.shared.validator.checkIfPasswordValid
 import java.util.UUID
 import javax.inject.Inject
@@ -100,6 +101,8 @@ class ResetPasswordViewModel @Inject constructor(
             }
         }.onSuccess {
             postSideEffect(ResetPasswordSideEffect.SendEmailVerificationCodeSuccess)
+        }.onFailure {
+            postSideEffect(ResetPasswordSideEffect.EmailVerificationTooManyRequest)
         }
 
     private fun updateEmailVerificationCode(value: String) = run {
@@ -221,4 +224,5 @@ sealed class ResetPasswordSideEffect : SideEffect() {
     data object EmailVerificationCodeIncorrect : ResetPasswordSideEffect()
     data object EmailVerificationSessionReset : ResetPasswordSideEffect()
     data object EmailVerificationSessionResetFailed : ResetPasswordSideEffect()
+    data object EmailVerificationTooManyRequest : ResetPasswordSideEffect()
 }

--- a/feature/src/main/java/team/aliens/dms/android/feature/signup/EnterEmailVerificationCodeScreen.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/signup/EnterEmailVerificationCodeScreen.kt
@@ -101,6 +101,10 @@ internal fun SignUpEnterEmailVerificationCodeScreen(
                 message = context.getString(R.string.sign_up_enter_email_verification_code_error_verification_code_incorrect),
             )
 
+            SignUpSideEffect.EmailVerificationTooManyRequest -> toast.showErrorToast(
+                message = context.getString(R.string.sign_up_enter_email_verification_code_error_too_many_request)
+            )
+
             SignUpSideEffect.EmailVerificationSessionReset -> {
                 isVerificationInputAvailable = true
                 with(timer) {

--- a/feature/src/main/java/team/aliens/dms/android/feature/signup/EnterEmailVerificationCodeScreen.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/signup/EnterEmailVerificationCodeScreen.kt
@@ -102,7 +102,7 @@ internal fun SignUpEnterEmailVerificationCodeScreen(
             )
 
             SignUpSideEffect.EmailVerificationTooManyRequest -> toast.showErrorToast(
-                message = context.getString(R.string.sign_up_enter_email_verification_code_error_too_many_request)
+                message = context.getString(R.string.reset_password_account_verification_error_too_many_request)
             )
 
             SignUpSideEffect.EmailVerificationSessionReset -> {

--- a/feature/src/main/java/team/aliens/dms/android/feature/signup/SignUpViewModel.kt
+++ b/feature/src/main/java/team/aliens/dms/android/feature/signup/SignUpViewModel.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.android.feature.signup
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -132,11 +133,16 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    private suspend fun sendEmailVerificationCode(email: String) =
-        authRepository.sendEmailVerificationCode(
-            email = email,
-            type = EmailVerificationType.SIGNUP,
-        )
+    private suspend fun sendEmailVerificationCode(email: String) {
+        runCatching {
+            authRepository.sendEmailVerificationCode(
+                email = email,
+                type = EmailVerificationType.SIGNUP,
+            )
+        }.onFailure {
+            postSideEffect(SignUpSideEffect.EmailVerificationTooManyRequest)
+        }
+    }
 
     private fun updateEmailVerificationCode(value: String) = run {
         if (value.length > EMAIL_VERIFICATION_CODE_LENGTH) {
@@ -438,6 +444,7 @@ sealed class SignUpSideEffect : SideEffect() {
     data object EmailVerificationCodeIncorrect : SignUpSideEffect()
     data object EmailVerificationSessionReset : SignUpSideEffect()
     data object EmailVerificationSessionResetFailed : SignUpSideEffect()
+    data object EmailVerificationTooManyRequest : SignUpSideEffect()
 
     // SetId
     class UserFound(val studentName: String) : SignUpSideEffect()

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="sign_up_enter_email_verification_code_error_cannot_resend_verification_code">인증 코드를 재발송할 수 없습니다</string>
     <string name="sign_up_enter_email_verification_code_error_verification_code_incorrect">인증 코드가 일치하지 않습니다</string>
     <string name="sign_up_enter_email_verification_code_error_timeout">인증 시간이 만료되었습니다</string>
+    <string name="sign_up_enter_email_verification_code_error_too_many_request">요청이 너무 많습니다 잠시 후 다시 시도해주세요</string>
     <string name="sign_up_send_email_verification_code">인증 코드 발송</string>
     <string name="sign_up_email_resent">이메일이 재전송되었습니다</string>
     <string name="sign_up_email_please_enter_verification_code">이메일로 전송된 인증코드 6자리를 입력해 주세요</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@
     <string name="reset_password_account_verification_identification_verification">본인확인 인증</string>
     <string name="reset_password_account_verification_success_account_id_matches_email">아이디와 일치하는 이메일입니다</string>
     <string name="reset_password_account_verification_enter_account_id_invalid_format">아이디 형식이 일치하지 않습니다.</string>
+    <string name="reset_password_account_verification_error_too_many_request">요청이 너무 많습니다 잠시 후 다시 시도해주세요</string>
     <string name="reset_password_account_verification_enter_student_name">이름 입력</string>
     <string name="reset_password_account_verification_enter_email">이메일 입력</string>
     <string name="reset_password_set_password_password_success_changed">비밀번호가 변경되었습니다.</string>


### PR DESCRIPTION
## 개요
> 이메일을 전송하는 api의 예외처리를 하지 않아 앱 크래쉬가 발생함

## 작업사항
- 이메일을 전송하는 api의 예외처리(TooManyRequest)를 적용시켰어요

## 추가 로 할 말
- 계정인증 Screen의 back stack 구현 필요
- sideEffect가 한 번만 발생시키도록 구현