### PR TITLE
🔀 :: (#770) device token 조회 비동기 순차적 처리

### DIFF
--- a/core/notification/src/main/java/team/aliens/dms/android/core/notification/DeviceTokenManager.kt
+++ b/core/notification/src/main/java/team/aliens/dms/android/core/notification/DeviceTokenManager.kt
@@ -4,6 +4,8 @@ import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import team.aliens.dms.android.data.notification.repository.NotificationRepository
 import javax.inject.Inject
 
@@ -15,13 +17,9 @@ class DeviceTokenManager @Inject constructor(
     }
 
     suspend fun fetchDeviceToken() {
-        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-            if (!task.isSuccessful) {
-                // TODO: Handle error
-            }
-            CoroutineScope(Dispatchers.IO).launch {
-                notificationRepository.saveDeviceToken(deviceToken = task.result)
-            }
+        val token = FirebaseMessaging.getInstance().token.await()
+        withContext(Dispatchers.IO) {
+            notificationRepository.saveDeviceToken(deviceToken = token)
         }
     }
 }


### PR DESCRIPTION
## 개요
> device token 로직을 리팩토링 하였습니다

## 작업사항
- device token 조회 시 addOnCompleteListener로 인해 task가 정상적으로 오지 않는 것을 파악함
- withContext 순차 처리 및 코루틴 적용

## 추가 로 할 말
