### PR TITLE
🔀 :: (#864) 저녁 시간 이후 급식 다음 날짜로 이동

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/meal/viewmodel/MealViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/meal/viewmodel/MealViewModel.kt
@@ -87,7 +87,7 @@ internal class MealViewModel @Inject constructor(
 @Immutable
 internal data class MealState(
     val meal: Meal = Meal(),
-    val selectedDate: LocalDate = today,
+    val selectedDate: LocalDate = getInitialDate(),
     val isShowCalendar: Boolean = false,
     val currentCardType: MealCardType = getProperMeal()
 )
@@ -101,3 +101,6 @@ internal fun getProperMeal(): MealCardType = when (now.hour) {
     in LUNCH_START_TIME until DINNER_START_TIME -> MealCardType.DINNER
     else -> MealCardType.BREAKFAST
 }
+
+private fun getInitialDate(): LocalDate =
+    if (now.hour >= DINNER_START_TIME) today.plusDays(1) else today


### PR DESCRIPTION
## 개요
>

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Meal selection now displays tomorrow's meal options when the app is opened after 7 PM, ensuring the correct meal schedule is shown based on the current time rather than just the calendar date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->