### PR TITLE
🔀 :: (#884) 로그인 시 accountId 공백 제거 처리 추가

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/signin/viewmodel/SignInViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/signin/viewmodel/SignInViewModel.kt
@@ -62,7 +62,7 @@ internal class SignInViewModel @Inject constructor(
             with(uiState.value) {
                 setState { this.copy(isLoading = true, buttonEnabled = false) }
                 authRepository.signIn(
-                    accountId = this.accountId,
+                    accountId = this.accountId.trim(),
                     password = this.password,
                     deviceToken = deviceToken,
                 ).onSuccess {

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/signin/viewmodel/SignInViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/signin/viewmodel/SignInViewModel.kt
@@ -24,7 +24,7 @@ internal class SignInViewModel @Inject constructor(
     internal fun setAccountId(accountId: String) {
         setState {
             it.copy(
-                accountId = accountId,
+                accountId = accountId.trim(),
                 showAccountIdErrorDescription = false,
             )
         }
@@ -62,7 +62,7 @@ internal class SignInViewModel @Inject constructor(
             with(uiState.value) {
                 setState { this.copy(isLoading = true, buttonEnabled = false) }
                 authRepository.signIn(
-                    accountId = this.accountId.trim(),
+                    accountId = this.accountId,
                     password = this.password,
                     deviceToken = deviceToken,
                 ).onSuccess {


### PR DESCRIPTION
## 개요
> 로그인 시 accountId에 공백이 포함되는 경우를 대비해 공백 제거 처리를 적용했습니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in now ignores leading/trailing spaces in account IDs, reducing failed attempts from accidental whitespace.
  * Error messaging behavior remains consistent and form controls (e.g., sign-in button) continue to behave as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->