### PR TITLE
🔀 :: (#888) 아이디 찾기 결과 다이얼로그 문구 수정

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
@@ -65,7 +65,7 @@ internal fun FindIdScreen(
     if (state.isShowIdDialog) {
         AlertDialog(
             title = { Text(text = "아이디 발송", style = DmsTheme.typography.sTitleM) },
-            text = { Text(text = "회원님의 아이디는 ${state.hashedEmail}에 발송되었습니다.", style = DmsTheme.typography.bodyM) },
+            text = { Text(text = "회원님의 아이디가 ${state.hashedEmail}로 발송되었습니다.", style = DmsTheme.typography.bodyM) },
             onDismissRequest = viewModel::hideDialog,
             confirmButton = {
                 DmsButton(

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
@@ -64,8 +64,8 @@ internal fun FindIdScreen(
 
     if (state.isShowIdDialog) {
         AlertDialog(
-            title = { Text(text = "아이디 찾기", style = DmsTheme.typography.sTitleM) },
-            text = { Text(text = "회원님의 아이디는 ${state.hashedEmail}입니다.", style = DmsTheme.typography.bodyM) },
+            title = { Text(text = "아이디 발송", style = DmsTheme.typography.sTitleM) },
+            text = { Text(text = "회원님의 아이디는 ${state.hashedEmail}에 발송되었습니다.", style = DmsTheme.typography.bodyM) },
             onDismissRequest = viewModel::hideDialog,
             confirmButton = {
                 DmsButton(


### PR DESCRIPTION
## 개요
> 아이디 찾기를 할 때 다이얼로그에 잘못 표시된 문구를 수정했습니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated ID recovery dialog messaging. The dialog title and confirmation text have been revised to reflect the new flow where user IDs are sent via email rather than displayed directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->