### PR TITLE
🔀 :: (#880) 코루틴 취소 전파를 위한 runcatching 개선

### DIFF
--- a/core/datastore/src/main/java/team/aliens/dms/android/core/datastore/util/TransformHandler.kt
+++ b/core/datastore/src/main/java/team/aliens/dms/android/core/datastore/util/TransformHandler.kt
@@ -3,6 +3,7 @@ package team.aliens.dms.android.core.datastore.util
 import team.aliens.dms.android.core.datastore.exception.TransformFailureException
 import kotlin.coroutines.cancellation.CancellationException
 
+@Suppress("TooGenericExceptionCaught")
 suspend inline fun <reified T> transform(
     onSuccess: (T) -> Unit = {},
     onFailure: (Throwable) -> Unit = { throw TransformFailureException() },
@@ -11,7 +12,7 @@ suspend inline fun <reified T> transform(
     block().also(onSuccess)
 } catch (exception: CancellationException) {
     throw exception
-} catch (throwable: Throwable) {
-    onFailure(throwable)
-    throw throwable
+} catch (exception: Exception) {
+    onFailure(exception)
+    throw exception
 }

--- a/core/datastore/src/main/java/team/aliens/dms/android/core/datastore/util/TransformHandler.kt
+++ b/core/datastore/src/main/java/team/aliens/dms/android/core/datastore/util/TransformHandler.kt
@@ -1,12 +1,17 @@
 package team.aliens.dms.android.core.datastore.util
 
 import team.aliens.dms.android.core.datastore.exception.TransformFailureException
+import kotlin.coroutines.cancellation.CancellationException
 
 suspend inline fun <reified T> transform(
     onSuccess: (T) -> Unit = {},
     onFailure: (Throwable) -> Unit = { throw TransformFailureException() },
     crossinline block: suspend () -> T,
-) = runCatching { block() }
-    .onSuccess(onSuccess)
-    .onFailure(onFailure)
-    .getOrThrow()
+) = try {
+    block().also(onSuccess)
+} catch (exception: CancellationException) {
+    throw exception
+} catch (throwable: Throwable) {
+    onFailure(throwable)
+    throw throwable
+}

--- a/core/device/src/main/kotlin/team/aliens/dms/android/core/device/datastore/DeviceDataStoreDataSourceImpl.kt
+++ b/core/device/src/main/kotlin/team/aliens/dms/android/core/device/datastore/DeviceDataStoreDataSourceImpl.kt
@@ -1,19 +1,19 @@
 package team.aliens.dms.android.core.device.datastore
 
 import team.aliens.dms.android.core.device.datastore.store.DeviceStore
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class DeviceDataStoreDataSourceImpl @Inject constructor(
     private val deviceStore: DeviceStore,
 ) : DeviceDataStoreDataSource() {
-    override suspend fun loadDeviceToken(): Result<String> = suspendRunCatching { deviceStore.loadDeviceToken() }
+    override suspend fun loadDeviceToken(): Result<String> = runCatchingCancellable { deviceStore.loadDeviceToken() }
 
-    override suspend fun storeDeviceToken(deviceToken: String): Result<Unit> = suspendRunCatching {
+    override suspend fun storeDeviceToken(deviceToken: String): Result<Unit> = runCatchingCancellable {
         deviceStore.storeDeviceToken(deviceToken)
     }
 
-    override suspend fun clearDeviceToken(): Result<Unit> = suspendRunCatching {
+    override suspend fun clearDeviceToken(): Result<Unit> = runCatchingCancellable {
         deviceStore.clearDeviceToken()
     }
 }

--- a/core/network/src/main/java/team/aliens/dms/android/core/network/util/NetworkExceptionMapper.kt
+++ b/core/network/src/main/java/team/aliens/dms/android/core/network/util/NetworkExceptionMapper.kt
@@ -10,6 +10,7 @@ import team.aliens.dms.android.core.network.exception.TooManyRequestsException
 import team.aliens.dms.android.core.network.exception.UnAuthorizedException
 import team.aliens.dms.android.core.network.exception.UnsupportedMediaTypeException
 import team.aliens.dms.android.shared.exception.NotDefinedException
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 
 // TODO: remove
 @Deprecated("can cover in network module")
@@ -25,7 +26,7 @@ suspend inline fun <T> statusMapping(
     onInternalServerError: () -> Nothing = { throw NotDefinedException() },
     onUnknownException: () -> Nothing = { throw NotDefinedException() },
     crossinline block: suspend () -> T,
-): T = runCatching { block() }
+): T = runCatchingCancellable { block() }
     .getOrElse { throwable ->
         when (throwable) {
             is BadRequestException -> onBadRequest()

--- a/core/widget/build.gradle.kts
+++ b/core/widget/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(project(ProjectPaths.DATA))
 
     implementation(project(ProjectPaths.Shared.DATE))
+    implementation(project(ProjectPaths.Shared.EXCEPTION))
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)

--- a/core/widget/src/main/kotlin/team/aliens/dms/android/core/widget/MealWorker.kt
+++ b/core/widget/src/main/kotlin/team/aliens/dms/android/core/widget/MealWorker.kt
@@ -19,6 +19,7 @@ import dagger.assisted.AssistedInject
 import team.aliens.dms.android.data.meal.repository.MealRepository
 import team.aliens.dms.android.shared.date.util.now
 import team.aliens.dms.android.shared.date.util.today
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -65,18 +66,22 @@ class MealWorker @AssistedInject constructor(
         val manager = GlanceAppWidgetManager(context)
         val glanceIds = manager.getGlanceIds(MealGlanceWidget::class.java)
 
-        return runCatching {
+        return runCatchingCancellable {
             setWidgetState(glanceIds, MealInfo.Loading)
 
             val mealDate = if (now.hour >= 19) today.plusDays(1) else today
-            val response = mealRepository.fetchMeal(mealDate).getOrThrow()
-            setWidgetState(glanceIds, response.toEntity())
-            Result.success()
-        }.getOrElse { throwable ->
-            setWidgetState(glanceIds, MealInfo.Unavailable)
-            android.util.Log.e("MealWorker", "Failed to update widget", throwable)
-            Result.failure()
-        }
+            mealRepository.fetchMeal(mealDate).getOrThrow()
+        }.fold(
+            onSuccess = { response ->
+                setWidgetState(glanceIds, response.toEntity())
+                Result.success()
+            },
+            onFailure = { throwable ->
+                setWidgetState(glanceIds, MealInfo.Unavailable)
+                android.util.Log.e("MealWorker", "Failed to update widget", throwable)
+                Result.failure()
+            },
+        )
     }
 
     private suspend fun setWidgetState(

--- a/core/widget/src/main/kotlin/team/aliens/dms/android/core/widget/MealWorker.kt
+++ b/core/widget/src/main/kotlin/team/aliens/dms/android/core/widget/MealWorker.kt
@@ -16,12 +16,14 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import team.aliens.dms.android.data.meal.repository.MealRepository
 import team.aliens.dms.android.shared.date.util.now
 import team.aliens.dms.android.shared.date.util.today
-import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.time.Duration
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
 
 @HiltWorker
 class MealWorker @AssistedInject constructor(
@@ -66,12 +68,19 @@ class MealWorker @AssistedInject constructor(
         val manager = GlanceAppWidgetManager(context)
         val glanceIds = manager.getGlanceIds(MealGlanceWidget::class.java)
 
-        return runCatchingCancellable {
-            setWidgetState(glanceIds, MealInfo.Loading)
+        setWidgetState(glanceIds, MealInfo.Loading)
 
-            val mealDate = if (now.hour >= 19) today.plusDays(1) else today
-            mealRepository.fetchMeal(mealDate).getOrThrow()
-        }.fold(
+        val mealDate = if (now.hour >= 19) today.plusDays(1) else today
+        val result = try {
+            mealRepository.fetchMeal(mealDate)
+        } catch (exception: CancellationException) {
+            withContext(NonCancellable) {
+                setWidgetState(glanceIds, MealInfo.Unavailable)
+            }
+            throw exception
+        }
+
+        return result.fold(
             onSuccess = { response ->
                 setWidgetState(glanceIds, response.toEntity())
                 Result.success()

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -42,6 +42,7 @@ android {
 dependencies {
 
     implementation(project(ProjectPaths.Shared.DATE))
+    implementation(project(ProjectPaths.Shared.EXCEPTION))
     implementation(project(ProjectPaths.Shared.MODEL))
 
     implementation(project(ProjectPaths.Core.DATABASE))

--- a/data/src/main/kotlin/team/aliens/dms/android/data/auth/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/auth/repository/AuthRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package team.aliens.dms.android.data.auth.repository
 
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import team.aliens.dms.android.core.jwt.JwtProvider
 import team.aliens.dms.android.core.school.SchoolProvider
 import team.aliens.dms.android.data.auth.mapper.extractFeatures
@@ -10,6 +12,7 @@ import team.aliens.dms.android.network.auth.model.CheckIdExistsResponse
 import team.aliens.dms.android.network.auth.model.SendEmailVerificationCodeRequest
 import team.aliens.dms.android.network.auth.model.SignInRequest
 import team.aliens.dms.android.network.auth.model.SignInResponse
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class AuthRepositoryImpl @Inject constructor(
@@ -65,11 +68,15 @@ internal class AuthRepositoryImpl @Inject constructor(
 //        networkAuthDataSource.checkIdExists(
 //            accountId = accountId,
 //        ).email
+    override suspend fun signOut(): Result<Unit> =
+        runCatchingCancellable {
+            clearSessionCaches()
+        }
 
-
-
-    override suspend fun signOut() = runCatching {
-        jwtProvider.clearCaches()
-        schoolProvider.clearCaches()
+    private suspend fun clearSessionCaches() {
+        withContext(NonCancellable) {
+            jwtProvider.clearCaches()
+            schoolProvider.clearCaches()
+        }
     }
 }

--- a/data/src/main/kotlin/team/aliens/dms/android/data/meal/repository/MealRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/meal/repository/MealRepositoryImpl.kt
@@ -8,31 +8,40 @@ import team.aliens.dms.android.data.meal.mapper.toModel
 import team.aliens.dms.android.data.meal.model.Meal
 import team.aliens.dms.android.database.meal.datasource.DatabaseMealDataSource
 import team.aliens.dms.android.network.meal.datasource.NetworkMealDataSource
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 
 internal class MealRepositoryImpl @Inject constructor(
     private val databaseMealDataSource: DatabaseMealDataSource,
     private val networkMealDataSource: NetworkMealDataSource,
 ) : MealRepository() {
-    override suspend fun fetchMeal(date: LocalDate): Result<Meal> = runCatching {
-        databaseMealDataSource.queryMeal(date).toModel()
-    }.recoverCatching {
-        try {
-            updateMeal(date).getOrThrow()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: CannotSaveMealException) {
-            throw e
-        } catch (_: Throwable) {
-            throw CannotSaveMealException()
+    override suspend fun fetchMeal(date: LocalDate): Result<Meal> {
+        val cachedMeal = runCatchingCancellable { databaseMealDataSource.queryMeal(date).toModel() }
+        if (cachedMeal.isSuccess) {
+            return cachedMeal
         }
+
+        return updateMeal(date).fold(
+            onSuccess = { Result.success(it) },
+            onFailure = { exception ->
+                when (exception) {
+                    is CannotSaveMealException -> Result.failure(exception)
+                    else -> Result.failure(CannotSaveMealException())
+                }
+            },
+        )
     }
 
     override suspend fun updateMeal(date: LocalDate): Result<Meal> =
-        networkMealDataSource.fetchMeals(date).mapCatching { response ->
-            response.toModel().also { meals ->
-                databaseMealDataSource.saveMeals(meals.toEntity())
-            }.find { it.date == date } ?: throw CannotFindMealException()
-        }
+        networkMealDataSource.fetchMeals(date).fold(
+            onSuccess = { response ->
+                runCatchingCancellable {
+                    val meals = response.toModel()
+                    databaseMealDataSource.saveMeals(meals.toEntity())
+
+                    meals.find { it.date == date } ?: throw CannotFindMealException()
+                }
+            },
+            onFailure = { Result.failure(it) },
+        )
 }

--- a/data/src/main/kotlin/team/aliens/dms/android/data/student/repository/StudentRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/student/repository/StudentRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package team.aliens.dms.android.data.student.repository
 
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import team.aliens.dms.android.core.jwt.JwtProvider
 import team.aliens.dms.android.core.school.SchoolProvider
 import team.aliens.dms.android.data.student.mapper.toModel
@@ -15,6 +17,7 @@ import team.aliens.dms.android.network.student.model.SignUpRequest
 import team.aliens.dms.android.network.student.model.SignUpResponse
 import team.aliens.dms.android.network.student.model.extractFeatures
 import team.aliens.dms.android.network.student.model.extractTokens
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -103,13 +106,19 @@ internal class StudentRepositoryImpl @Inject constructor(
 
 
     override suspend fun withdraw(): Result<Unit> {
-        return networkStudentDataSource.withdraw().onSuccess {
-            jwtProvider.clearCaches()
-            schoolProvider.clearCaches()
-        }
+        return networkStudentDataSource.withdraw().fold(
+            onSuccess = { runCatchingCancellable { clearSessionCaches() } },
+            onFailure = { Result.failure(it) },
+        )
     }
 
     override suspend fun fetchStudents(): Result<List<Student>> =
         networkStudentDataSource.fetchStudents().map { it.toModel() }
 
+    private suspend fun clearSessionCaches() {
+        withContext(NonCancellable) {
+            jwtProvider.clearCaches()
+            schoolProvider.clearCaches()
+        }
+    }
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.data.student.repository.StudentRepository
 import team.aliens.dms.android.network.school.datasource.NetworkSchoolDataSource
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,8 +44,9 @@ internal class FindIdViewModel @Inject constructor(
     }
 
     internal fun findId() = viewModelScope.launch {
-        val schoolId = runCatching { networkSchoolDataSource.fetchSchools() }
-            .getOrNull()?.schools?.firstOrNull()?.id ?: run {
+        val schoolId = runCatchingCancellable {
+            networkSchoolDataSource.fetchSchools().schools.firstOrNull()?.id
+        }.getOrNull() ?: run {
             sendEffect(FindIdSideEffect.ShowServerErrorSnackBar)
             return@launch
         }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/onboarding/viewmodel/OnboardingViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/onboarding/viewmodel/OnboardingViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.onboarding.datastore.OnboardingDataStoreDataSource
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 @HiltViewModel
@@ -15,7 +16,7 @@ class OnboardingViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
-            runCatching {
+            runCatchingCancellable {
                 onboardingDataSource.getOnboardingCompleted()
             }.onSuccess { isCompleted ->
                 setState {

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/profile/viewmodel/AdjustProfileViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/profile/viewmodel/AdjustProfileViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.data.student.repository.StudentRepository
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 @HiltViewModel
@@ -15,8 +16,8 @@ internal class AdjustProfileViewModel @Inject constructor(
 ): BaseStateViewModel<AdjustProfileState, AdjustProfileSideEffect>(AdjustProfileState()) {
 
     internal fun editProfile(profileImageUrl: String) = viewModelScope.launch(Dispatchers.IO) {
-        runCatching {
-            studentRepository.editProfile(profileImageUrl)
+        runCatchingCancellable {
+            studentRepository.editProfile(profileImageUrl).getOrThrow()
         }.onSuccess {
             sendEffect(AdjustProfileSideEffect.ProfileImageSet)
             setState { it.copy(buttonEnabled = false) }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/signup/viewmodel/EnterSchoolVerificationCodeViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/signup/viewmodel/EnterSchoolVerificationCodeViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.feature.signup.model.SignUpData
 import team.aliens.dms.android.network.school.datasource.NetworkSchoolDataSource
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 private const val SCHOOL_VERIFICATION_CODE_LENGTH = 8
@@ -29,7 +30,7 @@ internal class EnterSchoolVerificationCodeViewModel @Inject constructor(
     internal fun onNextClick() {
         viewModelScope.launch {
             setState { it.copy(isLoading = true, buttonEnabled = false) }
-            runCatching {
+            runCatchingCancellable {
                 networkSchoolDataSource.examineSchoolVerificationCode(uiState.value.verificationCode)
             }.onSuccess { response ->
                 setState { it.copy(isLoading = false, buttonEnabled = true) }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/signup/viewmodel/EnterSchoolVerificationQuestionViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/signup/viewmodel/EnterSchoolVerificationQuestionViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.feature.signup.model.SignUpData
 import team.aliens.dms.android.network.school.datasource.NetworkSchoolDataSource
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -24,7 +25,7 @@ internal class EnterSchoolVerificationQuestionViewModel @Inject constructor(
 
     private fun fetchQuestion() {
         viewModelScope.launch {
-            runCatching {
+            runCatchingCancellable {
                 networkSchoolDataSource.fetchSchoolVerificationQuestion(
                     schoolId = UUID.fromString(currentSignUpData.schoolId)
                 )
@@ -43,7 +44,7 @@ internal class EnterSchoolVerificationQuestionViewModel @Inject constructor(
     internal fun onNextClick() {
         viewModelScope.launch {
             setState { it.copy(isLoading = true) }
-            runCatching {
+            runCatchingCancellable {
                 networkSchoolDataSource.examineSchoolVerificationQuestion(
                     schoolId = UUID.fromString(currentSignUpData.schoolId),
                     answer = uiState.value.schoolVerificationAnswer,

--- a/network/src/main/kotlin/team/aliens/dms/android/network/auth/datasource/NetworkAuthDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/auth/datasource/NetworkAuthDataSourceImpl.kt
@@ -4,17 +4,17 @@ import team.aliens.dms.android.network.auth.model.CheckIdExistsResponse
 import team.aliens.dms.android.network.auth.model.SendEmailVerificationCodeRequest
 import team.aliens.dms.android.network.auth.model.SignInRequest
 import team.aliens.dms.android.network.auth.model.SignInResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class NetworkAuthDataSourceImpl @Inject constructor(
     private val authApiService: AuthApiService,
 ) : NetworkAuthDataSource() {
-    override suspend fun signIn(request: SignInRequest): Result<SignInResponse> = suspendRunCatching {
+    override suspend fun signIn(request: SignInRequest): Result<SignInResponse> = runCatchingCancellable {
         authApiService.signIn(request)
     }
 
-    override suspend fun sendEmailVerificationCode(request: SendEmailVerificationCodeRequest): Result<Unit> = suspendRunCatching {
+    override suspend fun sendEmailVerificationCode(request: SendEmailVerificationCodeRequest): Result<Unit> = runCatchingCancellable {
         authApiService.sendEmailVerificationCode(request)
     }
 
@@ -22,11 +22,11 @@ internal class NetworkAuthDataSourceImpl @Inject constructor(
         email: String,
         code: String,
         type: String,
-    ) = suspendRunCatching {
+    ) = runCatchingCancellable {
         authApiService.checkEmailVerificationCode(email, code, type)
     }
 
-    override suspend fun checkIdExists(accountId: String): Result<CheckIdExistsResponse> = suspendRunCatching {
+    override suspend fun checkIdExists(accountId: String): Result<CheckIdExistsResponse> = runCatchingCancellable {
         authApiService.checkIdExists(accountId)
     }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSourceImpl.kt
@@ -8,7 +8,7 @@ import team.aliens.dms.android.core.network.util.RequestType
 import team.aliens.dms.android.network.file.apiservice.FileApiService
 import team.aliens.dms.android.network.file.model.FetchFileUrlResponse
 import team.aliens.dms.android.network.file.model.FetchPresignedUrlResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.io.File
 import java.nio.file.Files
 import javax.inject.Inject
@@ -17,11 +17,11 @@ internal class NetworkFileDataSourceImpl @Inject constructor(
     private val fileApiService: FileApiService,
 ) : NetworkFileDataSource() {
     override suspend fun fetchPresignedUrl(fileName: String): Result<FetchPresignedUrlResponse> =
-        suspendRunCatching { fileApiService.fetchPresignedUrl(fileName) }
+        runCatchingCancellable { fileApiService.fetchPresignedUrl(fileName) }
 
     @RequiresApi(Build.VERSION_CODES.O)
     override suspend fun uploadFile(presignedUrl: String, file: File): Result<FetchFileUrlResponse> =
-        suspendRunCatching {
+        runCatchingCancellable {
             fileApiService.uploadFile(
                 presignedUrl = presignedUrl,
                 file = Files.readAllBytes(file.toPath()).toRequestBody(

--- a/network/src/main/kotlin/team/aliens/dms/android/network/meal/datasource/NetworkMealDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/meal/datasource/NetworkMealDataSourceImpl.kt
@@ -3,12 +3,12 @@ package team.aliens.dms.android.network.meal.datasource
 import java.time.LocalDate
 import team.aliens.dms.android.network.meal.apiservice.MealApiService
 import team.aliens.dms.android.network.meal.model.FetchMealsResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class NetworkMealDataSourceImpl @Inject constructor(
     private val mealApiService: MealApiService,
 ) : NetworkMealDataSource() {
     override suspend fun fetchMeals(date: LocalDate): Result<FetchMealsResponse> =
-        suspendRunCatching { mealApiService.fetchMeals(date) }
+        runCatchingCancellable { mealApiService.fetchMeals(date) }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/notice/datasource/NetworkNoticeDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/notice/datasource/NetworkNoticeDataSourceImpl.kt
@@ -4,7 +4,7 @@ import team.aliens.dms.android.network.notice.model.FetchLatestNoticeResponse
 import team.aliens.dms.android.network.notice.model.FetchNoticeDetailsResponse
 import team.aliens.dms.android.network.notice.model.FetchNoticesResponse
 import team.aliens.dms.android.network.notice.model.FetchWhetherNewNoticesExistResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -12,14 +12,14 @@ internal class NetworkNoticeDataSourceImpl @Inject constructor(
     private val noticeApiService: NoticeApiService,
 ) : NetworkNoticeDataSource() {
     override suspend fun fetchWhetherNewNoticesExist(): Result<FetchWhetherNewNoticesExistResponse> =
-        suspendRunCatching { noticeApiService.fetchWhetherNewNoticesExist() }
+        runCatchingCancellable { noticeApiService.fetchWhetherNewNoticesExist() }
 
     override suspend fun fetchNotices(order: String): Result<FetchNoticesResponse> =
-        suspendRunCatching { noticeApiService.fetchNotices(order) }
+        runCatchingCancellable { noticeApiService.fetchNotices(order) }
 
     override suspend fun fetchNoticeDetails(noticeId: UUID): Result<FetchNoticeDetailsResponse> =
-        suspendRunCatching { noticeApiService.fetchNoticeDetails(noticeId) }
+        runCatchingCancellable { noticeApiService.fetchNoticeDetails(noticeId) }
 
     override suspend fun fetchLatestNotice(): Result<FetchLatestNoticeResponse> =
-        suspendRunCatching { noticeApiService.fetchLatestNotice() }
+        runCatchingCancellable { noticeApiService.fetchLatestNotice() }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/notification/datasource/NetworkNotificationDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/notification/datasource/NetworkNotificationDataSourceImpl.kt
@@ -7,7 +7,7 @@ import team.aliens.dms.android.network.notification.model.FetchNotificationsResp
 import team.aliens.dms.android.network.notification.model.RegisterFcmDeviceTokenRequest
 import team.aliens.dms.android.network.notification.model.SubscribeNotificationTopicRequest
 import team.aliens.dms.android.network.notification.model.UnsubscribeNotificationTopicRequest
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -15,30 +15,30 @@ internal class NetworkNotificationDataSourceImpl @Inject constructor(
     private val notificationApiService: NotificationApiService,
 ) : NetworkNotificationDataSource() {
     override suspend fun registerFcmDeviceToken(request: RegisterFcmDeviceTokenRequest): Result<Unit> =
-        suspendRunCatching { notificationApiService.registerFcmDeviceToken(request) }
+        runCatchingCancellable { notificationApiService.registerFcmDeviceToken(request) }
 
     override suspend fun cancelFcmDeviceTokenRegistration(
         request: CancelFcmDeviceTokenRegistrationRequest,
     ): Result<Unit> =
-        suspendRunCatching { notificationApiService.cancelFcmDeviceTokenRegistration(request) }
+        runCatchingCancellable { notificationApiService.cancelFcmDeviceTokenRegistration(request) }
 
     override suspend fun subscribeNotificationTopic(request: SubscribeNotificationTopicRequest): Result<Unit> =
-        suspendRunCatching { notificationApiService.subscribeNotificationTopic(request) }
+        runCatchingCancellable { notificationApiService.subscribeNotificationTopic(request) }
 
     override suspend fun unsubscribeNotificationTopic(request: UnsubscribeNotificationTopicRequest): Result<Unit> =
-        suspendRunCatching { notificationApiService.unsubscribeNotificationTopic(request) }
+        runCatchingCancellable { notificationApiService.unsubscribeNotificationTopic(request) }
 
     override suspend fun batchUpdateNotificationTopic(request: BatchUpdateNotificationTopicRequest): Result<Unit> =
-        suspendRunCatching { notificationApiService.batchUpdateNotificationTopic(request) }
+        runCatchingCancellable { notificationApiService.batchUpdateNotificationTopic(request) }
 
     override suspend fun fetchNotificationTopicStatus(
         deviceToken: String,
     ): Result<FetchNotificationTopicStatusResponse> =
-        suspendRunCatching { notificationApiService.fetchNotificationTopicStatus(deviceToken) }
+        runCatchingCancellable { notificationApiService.fetchNotificationTopicStatus(deviceToken) }
 
     override suspend fun fetchNotifications(): Result<FetchNotificationsResponse> =
-        suspendRunCatching { notificationApiService.fetchNotifications() }
+        runCatchingCancellable { notificationApiService.fetchNotifications() }
 
     override suspend fun updateNotificationReadStatus(notification: UUID): Result<Unit> =
-        suspendRunCatching { notificationApiService.updateNotificationReadStatus(notification) }
+        runCatchingCancellable { notificationApiService.updateNotificationReadStatus(notification) }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/point/datasource/NetworkPointDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/point/datasource/NetworkPointDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package team.aliens.dms.android.network.point.datasource
 import team.aliens.dms.android.network.point.apiservice.PointApiService
 import team.aliens.dms.android.network.point.model.FetchPointsResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class NetworkPointDataSourceImpl @Inject constructor(
@@ -13,5 +13,5 @@ internal class NetworkPointDataSourceImpl @Inject constructor(
         page: Long?,
         size: Long?,
     ): Result<FetchPointsResponse> =
-        suspendRunCatching { pointApiService.fetchPoints(type, page, size) }
+        runCatchingCancellable { pointApiService.fetchPoints(type, page, size) }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSourceImpl.kt
@@ -3,7 +3,7 @@ import team.aliens.dms.android.network.remains.apiservice.RemainsApiService
 import team.aliens.dms.android.network.remains.model.FetchAppliedRemainsOptionResponse
 import team.aliens.dms.android.network.remains.model.FetchRemainsApplicationTimeResponse
 import team.aliens.dms.android.network.remains.model.FetchRemainsOptionsResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -11,14 +11,14 @@ internal class NetworkRemainsDataSourceImpl @Inject constructor(
     private val remainsApiService: RemainsApiService,
 ) : NetworkRemainsDataSource() {
     override suspend fun updateRemainsOption(optionId: UUID): Result<Unit> =
-        suspendRunCatching { remainsApiService.updateRemainsOption(optionId) }
+        runCatchingCancellable { remainsApiService.updateRemainsOption(optionId) }
 
     override suspend fun fetchAppliedRemainsOption(): Result<FetchAppliedRemainsOptionResponse> =
-        suspendRunCatching { remainsApiService.fetchAppliedRemainsOption() }
+        runCatchingCancellable { remainsApiService.fetchAppliedRemainsOption() }
 
     override suspend fun fetchRemainsApplicationTime(): Result<FetchRemainsApplicationTimeResponse> =
-        suspendRunCatching { remainsApiService.fetchRemainsApplicationTime() }
+        runCatchingCancellable { remainsApiService.fetchRemainsApplicationTime() }
 
     override suspend fun fetchRemainsOptions(): Result<FetchRemainsOptionsResponse> =
-        suspendRunCatching { remainsApiService.fetchRemainsOptions() }
+        runCatchingCancellable { remainsApiService.fetchRemainsOptions() }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/student/datasource/NetworkStudentDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/student/datasource/NetworkStudentDataSourceImpl.kt
@@ -9,7 +9,7 @@ import team.aliens.dms.android.network.student.model.FindIdResponse
 import team.aliens.dms.android.network.student.model.EditPasswordRequest
 import team.aliens.dms.android.network.student.model.SignUpRequest
 import team.aliens.dms.android.network.student.model.SignUpResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -18,7 +18,7 @@ internal class NetworkStudentDataSourceImpl @Inject constructor(
     private val studentProfileApiService: StudentProfileApiService,
 ) : NetworkStudentDataSource() {
     override suspend fun signUp(request: SignUpRequest): Result<SignUpResponse> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentAuthApiService.signUp(request)
         }
 
@@ -27,7 +27,7 @@ internal class NetworkStudentDataSourceImpl @Inject constructor(
         grade: Int,
         classroom: Int,
         number: Int,
-    ): Result<ExamineStudentNumberResponse> = suspendRunCatching {
+    ): Result<ExamineStudentNumberResponse> = runCatchingCancellable {
         studentAuthApiService.examineStudentNumber(
             schoolId = schoolId,
             grade = grade,
@@ -43,7 +43,7 @@ internal class NetworkStudentDataSourceImpl @Inject constructor(
         classRoom: Int,
         number: Int,
     ): Result<FindIdResponse> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentAuthApiService.findId(
                 schoolId = schoolId,
                 studentName = studentName,
@@ -54,31 +54,31 @@ internal class NetworkStudentDataSourceImpl @Inject constructor(
         }
 
     override suspend fun editPassword(request: EditPasswordRequest): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentAuthApiService.editPassword(request)
         }
 
     override suspend fun checkIdDuplication(id: String): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentAuthApiService.checkIdDuplication(id)
         }
 
     override suspend fun checkEmailDuplication(email: String): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentAuthApiService.checkEmailDuplication(email)
         }
 
     override suspend fun fetchMyPage(): Result<FetchMyPageResponse> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentProfileApiService.fetchMyPage()
         }
 
     override suspend fun editProfile(request: EditProfileRequest): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             studentProfileApiService.editProfile(request)
         }
 
-    override suspend fun withdraw() = suspendRunCatching { studentProfileApiService.withdraw() }
+    override suspend fun withdraw() = runCatchingCancellable { studentProfileApiService.withdraw() }
     override suspend fun fetchStudents(): Result<FetchStudentsResponse> =
-        suspendRunCatching { studentProfileApiService.fetchStudents() }
+        runCatchingCancellable { studentProfileApiService.fetchStudents() }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/user/datasource/NetworkUserDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/user/datasource/NetworkUserDataSourceImpl.kt
@@ -2,19 +2,19 @@ package team.aliens.dms.android.network.user.datasource
 
 import team.aliens.dms.android.network.user.apiservice.UserApiService
 import team.aliens.dms.android.network.user.model.EditPasswordRequest
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import javax.inject.Inject
 
 internal class NetworkUserDataSourceImpl @Inject constructor(
     private val userApiService: UserApiService,
 ) : NetworkUserDataSource() {
     override suspend fun editPassword(request: EditPasswordRequest): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             userApiService.editPassword(request)
         }
 
     override suspend fun comparePassword(password: String): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             userApiService.comparePassword(password)
         }
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/voting/datasource/NetworkVotingDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/voting/datasource/NetworkVotingDataSourceImpl.kt
@@ -5,7 +5,7 @@ import team.aliens.dms.android.network.voting.apiservice.VotingApiService
 import team.aliens.dms.android.network.voting.model.FetchAllVoteSearchResponse
 import team.aliens.dms.android.network.voting.model.FetchCheckVotingItemResponse
 import team.aliens.dms.android.network.voting.model.FetchModelStudentCandidatesResponse
-import team.aliens.dms.android.shared.exception.util.suspendRunCatching
+import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.util.UUID
 import javax.inject.Inject
 
@@ -13,21 +13,21 @@ internal class NetworkVotingDataSourceImpl @Inject constructor(
     private val votingApiService: VotingApiService,
 ) : NetworkVotingDataSource() {
     override suspend fun fetchAllVoteSearch(): Result<FetchAllVoteSearchResponse> =
-        suspendRunCatching { votingApiService.fetchAllVoteSearch() }
+        runCatchingCancellable { votingApiService.fetchAllVoteSearch() }
 
     override suspend fun fetchCheckVotingItem(votingTopicId: UUID): Result<FetchCheckVotingItemResponse> =
-        suspendRunCatching { votingApiService.fetchCheckVotingItem(votingTopicId) }
+        runCatchingCancellable { votingApiService.fetchCheckVotingItem(votingTopicId) }
 
     override suspend fun fetchCreateVotingItem(votingTopicId: UUID, selectedId: UUID): Result<Unit> =
-        suspendRunCatching {
+        runCatchingCancellable {
             votingApiService.fetchCreateVotingItem(votingTopicId, selectedId)
         }
 
     override suspend fun fetchDeleteVotingItem(voteId: UUID): Result<Unit> =
-        suspendRunCatching { votingApiService.fetchDeleteVotingItem(voteId) }
+        runCatchingCancellable { votingApiService.fetchDeleteVotingItem(voteId) }
 
     override suspend fun fetchModelStudentCandidates(
         requestDate: LocalDate,
     ): Result<FetchModelStudentCandidatesResponse> =
-        suspendRunCatching { votingApiService.fetchModelStudentCandidates(requestDate) }
+        runCatchingCancellable { votingApiService.fetchModelStudentCandidates(requestDate) }
 }

--- a/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/RunCatchingCancellable.kt
+++ b/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/RunCatchingCancellable.kt
@@ -1,0 +1,12 @@
+package team.aliens.dms.android.shared.exception.util
+
+import kotlin.coroutines.cancellation.CancellationException
+
+suspend inline fun <T> runCatchingCancellable(crossinline block: suspend () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (exception: CancellationException) {
+        throw exception
+    } catch (throwable: Throwable) {
+        Result.failure(throwable)
+    }

--- a/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/RunCatchingCancellable.kt
+++ b/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/RunCatchingCancellable.kt
@@ -2,11 +2,12 @@ package team.aliens.dms.android.shared.exception.util
 
 import kotlin.coroutines.cancellation.CancellationException
 
+@Suppress("TooGenericExceptionCaught")
 suspend inline fun <T> runCatchingCancellable(crossinline block: suspend () -> T): Result<T> =
     try {
         Result.success(block())
     } catch (exception: CancellationException) {
         throw exception
-    } catch (throwable: Throwable) {
-        Result.failure(throwable)
+    } catch (exception: Exception) {
+        Result.failure(exception)
     }

--- a/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/SuspendRunCatching.kt
+++ b/shared/exception/src/main/java/team/aliens/dms/android/shared/exception/util/SuspendRunCatching.kt
@@ -1,8 +1,0 @@
-package team.aliens.dms.android.shared.exception.util
-
-import kotlin.coroutines.cancellation.CancellationException
-
-inline fun <T> suspendRunCatching(block: () -> T): Result<T> =
-    runCatching(block).onFailure {
-        if (it is CancellationException) throw it
-    }


### PR DESCRIPTION
## 개요
>

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized cancellable exception handling across network, data, and repository layers by replacing legacy catch wrappers with a cancellable wrapper.
  * Made session-cache cleanup non-cancellable during sign-out/withdraw flows.
  * Updated background widget and datastore flows to handle coroutine cancellation more explicitly for more predictable behavior.
* **Bug Fixes**
  * Improved cancellation propagation to prevent unintended swallowing of cancellation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->