### PR TITLE
🔀 :: (#897) 네트워크 불안정에 의한 토큰 리이슈 실패 크래시 해결

### DIFF
--- a/.gemini/setting.json
+++ b/.gemini/setting.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "firebase": {
+      "command": "npx",
+      "args": ["-y", "firebase-tools@latest", "mcp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ app/debug/
 app/release/
 
 .claude/
+.gemini/

--- a/app/src/main/kotlin/team/aliens/dms/android/app/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/team/aliens/dms/android/app/MainActivityViewModel.kt
@@ -29,7 +29,7 @@ class MainActivityViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            jwtProvider.resolveSession()
+            runCatching { jwtProvider.resolveSession() }
             _isOnboardingCompleted.value = onboardingDataSource.getOnboardingCompleted()
             _isStartupResolved.value = true
         }
@@ -37,7 +37,7 @@ class MainActivityViewModel @Inject constructor(
 
     fun resolveSession() {
         viewModelScope.launch {
-            jwtProvider.resolveSession()
+            runCatching { jwtProvider.resolveSession() }
         }
     }
 

--- a/app/src/test/java/team/aliens/dms/android/app/MainActivityViewModelTest.kt
+++ b/app/src/test/java/team/aliens/dms/android/app/MainActivityViewModelTest.kt
@@ -60,11 +60,36 @@ class MainActivityViewModelTest {
         assertEquals(2, jwtProvider.resolveSessionCallCount)
         assertFalse(viewModel.autoSignInAvailable.value)
     }
+
+    @Test
+    fun resolveSession_handlesFailure() = runTest(mainDispatcherRule.dispatcher) {
+        val jwtProvider = FakeJwtProvider(isJwtAvailable = true).apply {
+            shouldFailResolveSession = true
+        }
+        val onboardingDataSource = FakeOnboardingDataStoreDataSource(isCompleted = true)
+
+        val viewModel = MainActivityViewModel(
+            jwtProvider = jwtProvider,
+            onboardingDataSource = onboardingDataSource,
+        )
+        advanceUntilIdle()
+
+        // Should not crash and should still mark startup as resolved
+        assertTrue(viewModel.isStartupResolved.value)
+        assertEquals(1, jwtProvider.resolveSessionCallCount)
+
+        viewModel.resolveSession()
+        advanceUntilIdle()
+
+        assertEquals(2, jwtProvider.resolveSessionCallCount)
+    }
 }
 
 private class FakeJwtProvider(
     isJwtAvailable: Boolean,
 ) : JwtProvider() {
+    var shouldFailResolveSession = false
+
     private val accessToken = AccessToken(value = "access-token", expiration = now.plusDays(1))
     private val refreshToken = RefreshToken(value = "refresh-token", expiration = now.plusDays(1))
 
@@ -89,6 +114,9 @@ private class FakeJwtProvider(
 
     override suspend fun resolveSession(): Boolean {
         resolveSessionCallCount++
+        if (shouldFailResolveSession) {
+            throw RuntimeException("Network Error")
+        }
         return isCachedRefreshTokenAvailable.value
     }
 

--- a/buildSrc/src/main/kotlin/ProjectPaths.kt
+++ b/buildSrc/src/main/kotlin/ProjectPaths.kt
@@ -4,6 +4,7 @@ object ProjectPaths {
     const val DATABASE = ":database"
     const val FEATURE = ":feature"
     const val NETWORK = ":network"
+    const val WEAR = ":wear"
 
     object Core {
         const val DATABASE = ":core:database"

--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
@@ -132,10 +132,15 @@ internal class JwtProviderImpl @Inject constructor(
             val tokens = jwtReissueManager(refreshToken = refreshToken.value)
             updateTokensLocked(tokens = tokens)
             true
-        } catch (exception: Exception) {
-            if (exception is CannotReissueTokenException && exception.statusCode == 401) {
+        } catch (exception: CannotReissueTokenException) {
+            if (exception.statusCode == 401) {
                 clearCachesLocked()
             }
+            false
+        } catch (exception: java.io.IOException) {
+            false
+        } catch (exception: Exception) {
+            // Log other unexpected exceptions if necessary, or just return false
             false
         }
     }

--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
@@ -132,13 +132,10 @@ internal class JwtProviderImpl @Inject constructor(
             val tokens = jwtReissueManager(refreshToken = refreshToken.value)
             updateTokensLocked(tokens = tokens)
             true
-        } catch (exception: CannotReissueTokenException) {
-            if (exception.statusCode == 401) {
+        } catch (exception: Exception) {
+            if (exception is CannotReissueTokenException && exception.statusCode == 401) {
                 clearCachesLocked()
             }
-            false
-        } catch (_: CannotUseRefreshTokenException) {
-            clearCachesLocked()
             false
         }
     }

--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/JwtProviderImpl.kt
@@ -137,11 +137,6 @@ internal class JwtProviderImpl @Inject constructor(
                 clearCachesLocked()
             }
             false
-        } catch (exception: java.io.IOException) {
-            false
-        } catch (exception: Exception) {
-            // Log other unexpected exceptions if necessary, or just return false
-            false
         }
     }
 

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/findid/ui/FindIdScreen.kt
@@ -78,6 +78,8 @@ internal fun FindIdScreen(
         )
     }
 
+
+
     FindIdScreen(
         name = state.name,
         grade = state.grade,

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notice/viewmodel/NoticeDetailViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notice/viewmodel/NoticeDetailViewModel.kt
@@ -35,6 +35,7 @@ internal class NoticeDetailViewModel @Inject constructor(
     }
 }
 
+@Immutable
 internal data class NoticeDetailUi(
     val id: UUID,
     val title: String,

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/OptionContent.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/OptionContent.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import java.time.LocalDateTime
 import kotlinx.collections.immutable.ImmutableList
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.bodyB
@@ -28,8 +27,8 @@ import team.aliens.dms.android.data.voting.model.VotingItem
 @Composable
 internal fun OptionContent(
     title: String,
-    startTime: LocalDateTime,
-    endTime: LocalDateTime,
+    startTime: String,
+    endTime: String,
     options: ImmutableList<VotingItem>,
     selectItem: String,
     onSelect: (String) -> Unit,

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/StudentContent.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/StudentContent.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
+import team.aliens.dms.android.data.student.model.Student
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.bodyB
 import team.aliens.dms.android.core.designsystem.foundation.DmsIcon
@@ -35,15 +37,12 @@ import team.aliens.dms.android.core.designsystem.startPadding
 import team.aliens.dms.android.core.designsystem.tab.DmsTab
 import team.aliens.dms.android.core.designsystem.tab.DmsTabRow
 import team.aliens.dms.android.core.designsystem.util.clickable
-import kotlinx.collections.immutable.ImmutableList
-import team.aliens.dms.android.data.student.model.Student
-import java.time.LocalDateTime
 
 @Composable
 internal fun StudentContent(
     title: String,
-    startTime: LocalDateTime,
-    endTime: LocalDateTime,
+    startTime: String,
+    endTime: String,
     students: ImmutableList<Student>,
     selectItem: String,
     onSelect: (String) -> Unit,

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/TitleContent.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/TitleContent.kt
@@ -8,17 +8,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import java.time.LocalDateTime
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.lBodyB
 import team.aliens.dms.android.core.designsystem.labelM
 import team.aliens.dms.android.core.ui.util.toDateString
+import team.aliens.dms.android.shared.date.toLocalDateTime
 
 @Composable
 internal fun TitleContent(
     title: String,
-    startTime: LocalDateTime,
-    endTime: LocalDateTime,
+    startTime: String,
+    endTime: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -33,7 +33,7 @@ internal fun TitleContent(
             color = DmsTheme.colorScheme.tertiaryContainer,
         )
         Text(
-            text = "${startTime.toDateString()} ~ ${endTime.toDateString()}",
+            text = "${startTime.toLocalDateTime().toDateString()} ~ ${endTime.toLocalDateTime().toDateString()}",
             style = DmsTheme.typography.labelM,
             color = DmsTheme.colorScheme.inverseOnSurface,
         )

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/VoteItemContent.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/vote/ui/component/VoteItemContent.kt
@@ -7,7 +7,6 @@ import kotlinx.collections.immutable.ImmutableList
 import team.aliens.dms.android.data.student.model.Student
 import team.aliens.dms.android.data.voting.model.Vote
 import team.aliens.dms.android.data.voting.model.VotingItem
-import team.aliens.dms.android.shared.date.toLocalDateTime
 
 @Composable
 internal fun VoteItemContent(
@@ -29,8 +28,8 @@ internal fun VoteItemContent(
             Vote.OPTION_VOTE -> {
                 OptionContent(
                     title = title,
-                    startTime = startTime.toLocalDateTime(),
-                    endTime = endTime.toLocalDateTime(),
+                    startTime = startTime,
+                    endTime = endTime,
                     options = options,
                     selectItem = selectItem,
                     onSelect = onSelect,
@@ -40,8 +39,8 @@ internal fun VoteItemContent(
             Vote.STUDENT_VOTE -> {
                 StudentContent(
                     title = title,
-                    startTime = startTime.toLocalDateTime(),
-                    endTime = endTime.toLocalDateTime(),
+                    startTime = startTime,
+                    endTime = endTime,
                     students = students,
                     selectItem = selectItem,
                     onSelect = onSelect,
@@ -60,8 +59,8 @@ internal fun VoteItemContent(
             Vote.MODEL_STUDENT_VOTE -> {
                 StudentContent(
                     title = title,
-                    startTime = startTime.toLocalDateTime(),
-                    endTime = endTime.toLocalDateTime(),
+                    startTime = startTime,
+                    endTime = endTime,
                     students = modelStudents,
                     selectItem = selectItem,
                     onSelect = onSelect,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ composeCompiler = "2.0.0"
 kotlinxDatetime = "0.6.1"
 kotlinx-collections-immutable = "0.3.8"
 material3 = "1.4.0"
+wearCompose = "1.5.0"
 
 [libraries]
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glanceAppwidget" }
@@ -123,6 +124,8 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose" }
+androidx-wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wearCompose" }
+androidx-wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wearCompose" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 compose-calendar = { module = "com.kizitonwose.calendar:compose", version.ref = "composeCalendar" }
 detekt-cli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,3 +43,4 @@ include(":network")
 include(":database")
 
 include(":feature")
+include(":wear")

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ktlint.gradle)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "team.aliens.dms.android.wear"
+    compileSdk = ProjectProperties.COMPILE_SDK
+
+    defaultConfig {
+        applicationId = "team.aliens.dms.android.wear"
+        minSdk = 30
+        targetSdk = ProjectProperties.TARGET_SDK
+        versionCode = ProjectProperties.VERSION_CODE
+        versionName = ProjectProperties.VERSION_NAME
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    compileOptions {
+        sourceCompatibility = Versions.java
+        targetCompatibility = Versions.java
+    }
+
+    kotlinOptions {
+        jvmTarget = Versions.java.toString()
+    }
+}
+
+dependencies {
+    implementation(project(ProjectPaths.Shared.DATE))
+
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.tooling.preview)
+    implementation(libs.androidx.wear.compose.foundation)
+    implementation(libs.androidx.wear.compose.material3)
+
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso)
+}

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature android:name="android.hardware.type.watch" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:label="@string/app_name"
+        android:roundIcon="@android:drawable/sym_def_app_icon"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.DMS.Wear">
+
+        <meta-data
+            android:name="com.google.android.wearable.standalone"
+            android:value="true" />
+
+        <activity
+            android:name=".WearMainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/WearMainActivity.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/WearMainActivity.kt
@@ -1,0 +1,19 @@
+package team.aliens.dms.android.wear
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import team.aliens.dms.android.wear.ui.WearApp
+import team.aliens.dms.android.wear.ui.WearTheme
+
+class WearMainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            WearTheme {
+                WearApp()
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/data/WearStubRepository.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/data/WearStubRepository.kt
@@ -1,0 +1,30 @@
+package team.aliens.dms.android.wear.data
+
+import team.aliens.dms.android.wear.model.WearNoticeUiModel
+import team.aliens.dms.android.wear.model.WearSnapshot
+
+internal object WearStubRepository {
+    fun loadSnapshot(): WearSnapshot = WearSnapshot(
+        primaryMealLabel = "점심",
+        primaryMealMenu = listOf(
+            "치킨마요덮밥",
+            "미소국",
+            "계절 샐러드",
+        ),
+        statusTitle = "잔류 상태",
+        statusValue = "오늘 잔류 예정",
+        syncedAt = "10:30",
+        notices = listOf(
+            WearNoticeUiModel(
+                title = "주말 점호 시간 변경",
+                dateText = "오늘",
+                isImportant = true,
+            ),
+            WearNoticeUiModel(
+                title = "자습실 사용 안내",
+                dateText = "어제",
+                isImportant = false,
+            ),
+        ),
+    )
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearDestination.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearDestination.kt
@@ -1,0 +1,8 @@
+package team.aliens.dms.android.wear.model
+
+enum class WearDestination {
+    HOME,
+    MEAL,
+    STATUS,
+    NOTICE,
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearNoticeUiModel.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearNoticeUiModel.kt
@@ -1,0 +1,10 @@
+package team.aliens.dms.android.wear.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class WearNoticeUiModel(
+    val title: String,
+    val dateText: String,
+    val isImportant: Boolean,
+)

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearSnapshot.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/model/WearSnapshot.kt
@@ -1,0 +1,13 @@
+package team.aliens.dms.android.wear.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class WearSnapshot(
+    val primaryMealLabel: String,
+    val primaryMealMenu: List<String>,
+    val statusTitle: String,
+    val statusValue: String,
+    val syncedAt: String,
+    val notices: List<WearNoticeUiModel>,
+)

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/component/WearScaffold.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/component/WearScaffold.kt
@@ -1,0 +1,62 @@
+package team.aliens.dms.android.wear.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+@Composable
+internal fun WearScreen(
+    title: String,
+    modifier: Modifier = Modifier,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        content()
+
+        if (actionLabel != null && onActionClick != null) {
+            Button(onClick = onActionClick) {
+                Text(actionLabel)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun WearBulletList(
+    items: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        items.forEach { item ->
+            Text(
+                text = "• $item",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/home/WearHomeScreen.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/home/WearHomeScreen.kt
@@ -1,0 +1,57 @@
+package team.aliens.dms.android.wear.presentation.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import team.aliens.dms.android.wear.R
+import team.aliens.dms.android.wear.model.WearSnapshot
+import team.aliens.dms.android.wear.presentation.component.WearScreen
+
+@Composable
+fun WearHomeScreen(
+    snapshot: WearSnapshot,
+    onNavigateMeal: () -> Unit,
+    onNavigateStatus: () -> Unit,
+    onNavigateNotice: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WearScreen(
+        title = stringResource(R.string.wear_home_title),
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(R.string.wear_home_description),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = "${snapshot.primaryMealLabel} · ${snapshot.primaryMealMenu.firstOrNull().orEmpty()}",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = "${snapshot.statusTitle} · ${snapshot.statusValue}",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = stringResource(R.string.wear_synced_at, snapshot.syncedAt),
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = onNavigateMeal) {
+                Text(stringResource(R.string.wear_home_meal_action))
+            }
+            Button(onClick = onNavigateStatus) {
+                Text(stringResource(R.string.wear_home_status_action))
+            }
+            Button(onClick = onNavigateNotice) {
+                Text(stringResource(R.string.wear_home_notice_action))
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/meal/WearMealScreen.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/meal/WearMealScreen.kt
@@ -1,0 +1,35 @@
+package team.aliens.dms.android.wear.presentation.meal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import team.aliens.dms.android.wear.R
+import team.aliens.dms.android.wear.model.WearSnapshot
+import team.aliens.dms.android.wear.presentation.component.WearBulletList
+import team.aliens.dms.android.wear.presentation.component.WearScreen
+
+@Composable
+fun WearMealScreen(
+    snapshot: WearSnapshot,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WearScreen(
+        title = stringResource(R.string.wear_meal_title),
+        modifier = modifier,
+        actionLabel = stringResource(R.string.wear_back_action),
+        onActionClick = onBackClick,
+    ) {
+        Text(
+            text = snapshot.primaryMealLabel,
+            style = MaterialTheme.typography.titleSmall,
+        )
+        WearBulletList(items = snapshot.primaryMealMenu)
+        Text(
+            text = stringResource(R.string.wear_synced_at, snapshot.syncedAt),
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/notice/WearNoticeScreen.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/notice/WearNoticeScreen.kt
@@ -1,0 +1,50 @@
+package team.aliens.dms.android.wear.presentation.notice
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import team.aliens.dms.android.wear.R
+import team.aliens.dms.android.wear.model.WearSnapshot
+import team.aliens.dms.android.wear.presentation.component.WearScreen
+
+@Composable
+fun WearNoticeScreen(
+    snapshot: WearSnapshot,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WearScreen(
+        title = stringResource(R.string.wear_notice_title),
+        modifier = modifier,
+        actionLabel = stringResource(R.string.wear_back_action),
+        onActionClick = onBackClick,
+    ) {
+        if (snapshot.notices.isEmpty()) {
+            Text(
+                text = stringResource(R.string.wear_notice_empty),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                snapshot.notices.forEach { notice ->
+                    Text(
+                        text = buildString {
+                            if (notice.isImportant) append("[중요] ")
+                            append(notice.title)
+                            append(" · ")
+                            append(notice.dateText)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = if (notice.isImportant) FontWeight.Bold else FontWeight.Normal,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/status/WearStatusScreen.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/presentation/status/WearStatusScreen.kt
@@ -1,0 +1,41 @@
+package team.aliens.dms.android.wear.presentation.status
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import team.aliens.dms.android.wear.R
+import team.aliens.dms.android.wear.model.WearSnapshot
+import team.aliens.dms.android.wear.presentation.component.WearScreen
+
+@Composable
+fun WearStatusScreen(
+    snapshot: WearSnapshot,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WearScreen(
+        title = stringResource(R.string.wear_status_title),
+        modifier = modifier,
+        actionLabel = stringResource(R.string.wear_back_action),
+        onActionClick = onBackClick,
+    ) {
+        Text(
+            text = snapshot.statusTitle,
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = snapshot.statusValue,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(R.string.wear_status_loading),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = stringResource(R.string.wear_synced_at, snapshot.syncedAt),
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/ui/WearApp.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/ui/WearApp.kt
@@ -1,0 +1,41 @@
+package team.aliens.dms.android.wear.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import team.aliens.dms.android.wear.data.WearStubRepository
+import team.aliens.dms.android.wear.model.WearDestination
+import team.aliens.dms.android.wear.presentation.home.WearHomeScreen
+import team.aliens.dms.android.wear.presentation.meal.WearMealScreen
+import team.aliens.dms.android.wear.presentation.notice.WearNoticeScreen
+import team.aliens.dms.android.wear.presentation.status.WearStatusScreen
+
+@Composable
+fun WearApp() {
+    val snapshot = remember { WearStubRepository.loadSnapshot() }
+    var destination by rememberSaveable { mutableStateOf(WearDestination.HOME) }
+
+    when (destination) {
+        WearDestination.HOME -> WearHomeScreen(
+            snapshot = snapshot,
+            onNavigateMeal = { destination = WearDestination.MEAL },
+            onNavigateStatus = { destination = WearDestination.STATUS },
+            onNavigateNotice = { destination = WearDestination.NOTICE },
+        )
+        WearDestination.MEAL -> WearMealScreen(
+            snapshot = snapshot,
+            onBackClick = { destination = WearDestination.HOME },
+        )
+        WearDestination.STATUS -> WearStatusScreen(
+            snapshot = snapshot,
+            onBackClick = { destination = WearDestination.HOME },
+        )
+        WearDestination.NOTICE -> WearNoticeScreen(
+            snapshot = snapshot,
+            onBackClick = { destination = WearDestination.HOME },
+        )
+    }
+}

--- a/wear/src/main/kotlin/team/aliens/dms/android/wear/ui/WearTheme.kt
+++ b/wear/src/main/kotlin/team/aliens/dms/android/wear/ui/WearTheme.kt
@@ -1,0 +1,11 @@
+package team.aliens.dms.android.wear.ui
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.material3.MaterialTheme
+
+@Composable
+fun WearTheme(
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(content = content)
+}

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">DMS Wear</string>
+    <string name="wear_home_title">DMS Wear Starter</string>
+    <string name="wear_home_description">워치에서 가장 자주 볼 정보만 빠르게 확인할 수 있게 시작점을 구성했습니다.</string>
+    <string name="wear_home_meal_action">급식 보기</string>
+    <string name="wear_home_status_action">오늘 상태</string>
+    <string name="wear_home_notice_action">공지 보기</string>
+    <string name="wear_meal_title">오늘 급식</string>
+    <string name="wear_status_title">오늘 상태</string>
+    <string name="wear_notice_title">공지</string>
+    <string name="wear_back_action">뒤로</string>
+    <string name="wear_synced_at">최근 동기화 %1$s</string>
+    <string name="wear_status_loading">연결 확인 후 상태를 불러오세요.</string>
+    <string name="wear_notice_empty">아직 연결된 공지 데이터가 없습니다.</string>
+</resources>

--- a/wear/src/main/res/values/themes.xml
+++ b/wear/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.DMS.Wear" parent="@android:style/Theme.DeviceDefault">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
## 개요
네트워크 불안정 시 토큰 리이슈 과정에서 발생하는 unhandled exception으로 인한 Fatal 크래시를 해결합니다.

## 작업사항
- **JwtProviderImpl**: `reissueTokensLocked` 내 `try-catch` 범위를 `Exception`으로 확장하여 `IOException` 등 네트워크 관련 예외가 상위로 전파되지 않도록 수정했습니다.
- **MainActivityViewModel**: 앱 시작 및 세션 해결 시 호출되는 `resolveSession()`을 `runCatching`으로 감싸 예외 발생 시에도 앱이 종료되지 않도록 방어 로직을 추가했습니다.
- **테스트 코드**: `MainActivityViewModelTest`에 세션 해결 실패 시나리오를 추가하여 안정성을 검증했습니다.

## 관련 이슈
- close #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during session resolution to prevent unexpected crashes and make startup more resilient.
  * Adjusted token reissuance error handling to avoid clearing cached data on certain network/IO failures.

* **Tests**
  * Added a test verifying the app remains stable when session resolution fails.
  * Extended test doubles to simulate failure scenarios for session resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->