### PR TITLE
🔀 :: (#942) 새벽 자습 신청 화면 사용성 개선

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyCalendarSection.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyCalendarSection.kt
@@ -387,10 +387,20 @@ private fun buildCalendarDates(
 }
 
 private fun isSelectableDate(date: LocalDate): Boolean {
-    val startOfThisWeek = LocalDate.now()
-        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-    val endOfThisWeek = startOfThisWeek.plusDays(3)
+    val today = LocalDate.now()
 
-    return !date.isBefore(startOfThisWeek) &&
-            !date.isAfter(endOfThisWeek)
+    val startOfSelectableWeek = if (
+        today.dayOfWeek == DayOfWeek.FRIDAY ||
+        today.dayOfWeek == DayOfWeek.SATURDAY ||
+        today.dayOfWeek == DayOfWeek.SUNDAY
+    ) {
+        today.with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+    } else {
+        today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    }
+
+    val endOfSelectableWeek = startOfSelectableWeek.plusDays(3)
+
+    return !date.isBefore(startOfSelectableWeek) &&
+            !date.isAfter(endOfSelectableWeek)
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyCalendarSection.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyCalendarSection.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.temporal.TemporalAdjusters
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.bodyB
 import team.aliens.dms.android.core.designsystem.labelM
@@ -56,7 +57,7 @@ fun LateStudyCalendarSection(
             )
 
             Text(
-                text = "(새벽 자습은 금, 토, 일요일은 불가능합니다)",
+                text = "(이번 주 월~목만 신청할 수 있습니다)",
                 color = DmsTheme.colorScheme.inverseSurface,
                 style = DmsTheme.typography.labelM,
             )
@@ -386,10 +387,10 @@ private fun buildCalendarDates(
 }
 
 private fun isSelectableDate(date: LocalDate): Boolean {
-    return when (date.dayOfWeek) {
-        DayOfWeek.FRIDAY,
-        DayOfWeek.SATURDAY,
-        DayOfWeek.SUNDAY -> false
-        else -> true
-    }
+    val startOfThisWeek = LocalDate.now()
+        .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    val endOfThisWeek = startOfThisWeek.plusDays(3)
+
+    return !date.isBefore(startOfThisWeek) &&
+            !date.isAfter(endOfThisWeek)
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyReasonSection.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyReasonSection.kt
@@ -1,6 +1,5 @@
 package team.aliens.dms.android.feature.latestudy.ui.component
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -28,7 +27,6 @@ import team.aliens.dms.android.core.designsystem.labelM
 
 private const val REASON_MAX_LENGTH = 200
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LateStudyReasonSection(
     value: String,

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyReasonSection.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/component/LateStudyReasonSection.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.android.feature.latestudy.ui.component
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,12 +8,19 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.bodyB
 import team.aliens.dms.android.core.designsystem.bodyM
@@ -20,12 +28,16 @@ import team.aliens.dms.android.core.designsystem.labelM
 
 private const val REASON_MAX_LENGTH = 200
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LateStudyReasonSection(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val coroutineScope = rememberCoroutineScope()
+
     LateStudySectionCard(modifier = modifier) {
         Row(
             modifier = Modifier
@@ -56,6 +68,7 @@ fun LateStudyReasonSection(
                     shape = RoundedCornerShape(20.dp),
                 )
                 .height(180.dp)
+                .bringIntoViewRequester(bringIntoViewRequester)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
         ) {
             BasicTextField(
@@ -65,7 +78,16 @@ fun LateStudyReasonSection(
                         onValueChange(newValue)
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            coroutineScope.launch {
+                                delay(250)
+                                bringIntoViewRequester.bringIntoView()
+                            }
+                        }
+                    },
                 textStyle = DmsTheme.typography.bodyM.copy(
                     color = DmsTheme.colorScheme.onBackground,
                 ),

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
@@ -195,18 +195,22 @@ private fun StudyApplicationStatusResponse.buildRangeText(
     return when {
         start != null && end != null -> {
             if (start == end) {
-                "$startDate $suffix"
+                "${start.toMonthDayText()} $suffix"
             } else {
-                "$startDate ~ $endDate $suffix"
+                "${start.toMonthDayText()} ~ ${end.toMonthDayText()} $suffix"
             }
         }
 
-        start != null -> "$startDate $suffix"
+        start != null -> "${start.toMonthDayText()} $suffix"
 
-        end != null -> "$endDate $suffix"
+        end != null -> "${end.toMonthDayText()} $suffix"
 
         else -> null
     }
+}
+
+private fun LocalDate.toMonthDayText(): String {
+    return "${monthValue}.${dayOfMonth}"
 }
 
 private fun StudyApplicationStatusResponse.toUiStatus(): LateStudyStatusUi? {


### PR DESCRIPTION
## 개요
> 
- 사유 입력 시 키보드에 입력창이 가려지지 않도록 개선
- 새벽자습 날짜 이번 주 월~목만 선택 가능하도록 변경
- 신청 상태 날짜 표시에서 연도 제거

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text input field now automatically scrolls into view when focused to improve accessibility and usability.
  * Late-study “일정” availability updated to allow selections only for Mon–Thu within the current week.

* **UI Improvements**
  * Improved late-study application title date formatting to consistently show dates as `month.day` for clearer date ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->