### PR TITLE
🔀 :: (#946) 새벽 자습 알림 토픽 누락 해결

### DIFF
--- a/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/NotificationTopic.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/NotificationTopic.kt
@@ -3,7 +3,7 @@ package team.aliens.dms.android.data.notification.model
 import team.aliens.dms.android.network.notification.model.BatchUpdateNotificationTopicRequest
 
 enum class NotificationTopic {
-    NOTICE, STUDY_ROOM_TIME_SLOT, STUDY_ROOM_APPLY, POINT, OUTING,
+    NOTICE, STUDY_ROOM_TIME_SLOT, STUDY_ROOM_APPLY, POINT, OUTING, DAYBREAK_STUDY_APPLICATION,
     ;
 
     data class Subscription(


### PR DESCRIPTION
## 개요
> DAYBREAK_STUDY_APPLICATION 토픽 누락으로 인한 알림 조회 오류를 해결합니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new notification topic, enabling notifications for the Daybreak Study Application feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->