### PR TITLE
🔀 :: (#958) 푸시 알림 비활성화 시 공지 탭이 비어 보임 문제 해결

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/NotificationScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/NotificationScreen.kt
@@ -50,6 +50,7 @@ import team.aliens.dms.android.feature.notification.viewmodel.NotificationSideEf
 import team.aliens.dms.android.feature.notification.viewmodel.NotificationState
 import team.aliens.dms.android.feature.notification.viewmodel.NotificationUi
 import team.aliens.dms.android.feature.notification.viewmodel.NotificationViewModel
+import team.aliens.dms.android.feature.notification.viewmodel.NoticeUi
 import java.util.UUID
 
 @Composable
@@ -77,10 +78,18 @@ internal fun Notification(
         viewModel.sideEffect.collect {
             when (it) {
                 is NotificationSideEffect.FailFetchNotification -> updatedOnShowSnackBar(
-                    DmsSnackBarType.ERROR, "알림 조회를 실패했어요"
+                    DmsSnackBarType.ERROR,
+                    "알림 조회를 실패했어요",
                 )
+
+                is NotificationSideEffect.FailFetchNotice -> updatedOnShowSnackBar(
+                    DmsSnackBarType.ERROR,
+                    "공지 조회를 실패했어요",
+                )
+
                 is NotificationSideEffect.FailUpdateNotification -> updatedOnShowSnackBar(
-                    DmsSnackBarType.ERROR, "업데이트 실패 했어요"
+                    DmsSnackBarType.ERROR,
+                    "업데이트 실패 했어요",
                 )
             }
         }
@@ -97,10 +106,7 @@ internal fun Notification(
             }
         },
         onBackClick = onBackClick,
-        onNotificationDetailClick = { linkId, notificationId ->
-            viewModel.updateNotificationReadStatus(notificationId)
-            onNavigateNotificationDetailClick(linkId)
-        },
+        onNotificationDetailClick = onNavigateNotificationDetailClick,
         onNotificationClick = { point, notificationId ->
             viewModel.updateNotificationReadStatus(notificationId)
             onNavigatePointHistory(point)
@@ -116,7 +122,7 @@ private fun NotificationScreen(
     tabIndex: Int,
     onTabClick: (Int) -> Unit,
     onBackClick: () -> Unit,
-    onNotificationDetailClick: (UUID, UUID) -> Unit,
+    onNotificationDetailClick: (UUID) -> Unit,
     onNotificationClick: (PointType, UUID) -> Unit,
 ) {
     Column(
@@ -126,9 +132,7 @@ private fun NotificationScreen(
             .systemBarsPadding(),
     ) {
         DmsTopAppBar(onBackClick = onBackClick)
-        DmsTabRow(
-            selectedTabIndex = tabIndex,
-        ) {
+        DmsTabRow(selectedTabIndex = tabIndex) {
             tabData.forEachIndexed { index, text ->
                 DmsTab(
                     selected = tabIndex == index,
@@ -140,7 +144,7 @@ private fun NotificationScreen(
         HorizontalPager(
             modifier = Modifier.fillMaxWidth(),
             state = pagerState,
-            beyondViewportPageCount = 1
+            beyondViewportPageCount = 1,
         ) { page ->
             if (page == 0) {
                 NotificationItems(
@@ -154,7 +158,6 @@ private fun NotificationScreen(
                 )
             }
         }
-
     }
 }
 
@@ -164,13 +167,11 @@ internal fun NotificationItems(
     onNotificationClick: (PointType, UUID) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxWidth()
-    ) {
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
         items(
             items = notifications,
-            key = { item -> item.id }
-        ) {notification ->
+            key = { item -> item.id },
+        ) { notification ->
             NotificationItem(
                 notification = notification,
                 onNotificationClick = onNotificationClick,
@@ -181,13 +182,11 @@ internal fun NotificationItems(
 
 @Composable
 private fun NoticeItems(
-    notices: ImmutableList<NotificationUi>,
-    onNotificationDetailClick: (UUID, UUID) -> Unit,
+    notices: ImmutableList<NoticeUi>,
+    onNotificationDetailClick: (UUID) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-    ) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
         items(
             items = notices,
             key = { item -> item.id },
@@ -209,24 +208,33 @@ internal fun NotificationItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = { onNotificationClick(notification.pointDetailTopic, notification.id) })
+            .clickable(
+                onClick = {
+                    onNotificationClick(
+                        notification.pointDetailTopic,
+                        notification.id,
+                    )
+                },
+            )
             .padding(horizontal = 24.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
-            painter = painterResource(if (notification.pointDetailTopic == PointType.MINUS) DmsIcon.Minus else DmsIcon.Plus),
+            painter = painterResource(
+                if (notification.pointDetailTopic == PointType.MINUS) {
+                    DmsIcon.Minus
+                } else {
+                    DmsIcon.Plus
+                },
+            ),
             contentDescription = null,
         )
-        Column(
-            modifier = Modifier.startPadding(12.dp),
-        ) {
+        Column(modifier = Modifier.startPadding(12.dp)) {
             Text(
                 text = notification.title,
                 style = DmsTheme.typography.bodyM,
             )
-            Row(
-                modifier = Modifier.topPadding(6.dp)
-            ) {
+            Row(modifier = Modifier.topPadding(6.dp)) {
                 if (!notification.isRead) {
                     Icon(
                         modifier = Modifier.size(4.dp),
@@ -236,8 +244,7 @@ internal fun NotificationItem(
                     )
                 }
                 Text(
-                    modifier = Modifier
-                        .startPadding(4.dp),
+                    modifier = Modifier.startPadding(4.dp),
                     text = notification.content,
                     style = DmsTheme.typography.labelM,
                 )

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/component/NoticeItem.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/component/NoticeItem.kt
@@ -5,9 +5,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,26 +15,22 @@ import androidx.compose.ui.unit.dp
 import team.aliens.dms.android.core.designsystem.DmsTheme
 import team.aliens.dms.android.core.designsystem.bodyM
 import team.aliens.dms.android.core.designsystem.foundation.DmsIcon
-import team.aliens.dms.android.core.designsystem.labelM
 import team.aliens.dms.android.core.designsystem.startPadding
-import team.aliens.dms.android.core.designsystem.topPadding
 import team.aliens.dms.android.core.designsystem.util.clickable
-import team.aliens.dms.android.feature.notification.viewmodel.NotificationUi
+import team.aliens.dms.android.feature.notification.viewmodel.NoticeUi
 import java.util.UUID
 
 @Composable
 internal fun NoticeItem(
-    notice: NotificationUi,
-    onNotificationDetailClick: (UUID, UUID) -> Unit,
+    notice: NoticeUi,
+    onNotificationDetailClick: (UUID) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-    ) {
+    Column(modifier = modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = { onNotificationDetailClick(notice.linkId, notice.id) })
+                .clickable(onClick = { onNotificationDetailClick(notice.id) })
                 .padding(horizontal = 24.dp, vertical = 22.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -46,32 +39,11 @@ internal fun NoticeItem(
                 tint = DmsTheme.colorScheme.scrim,
                 contentDescription = null,
             )
-            Column(
+            Text(
                 modifier = Modifier.startPadding(12.dp),
-            ) {
-                Text(
-                    text = notice.title,
-                    style = DmsTheme.typography.bodyM,
-                )
-                Row(
-                    modifier = Modifier.topPadding(6.dp)
-                ) {
-                    if (!notice.isRead) {
-                        Icon(
-                            modifier = Modifier.size(4.dp),
-                            imageVector = Icons.Filled.Circle,
-                            contentDescription = null,
-                            tint = DmsTheme.colorScheme.primaryContainer,
-                        )
-                    }
-                    Text(
-                        modifier = Modifier
-                            .startPadding(4.dp),
-                        text = notice.content,
-                        style = DmsTheme.typography.labelM,
-                    )
-                }
-            }
+                text = notice.title,
+                style = DmsTheme.typography.bodyM,
+            )
             Spacer(modifier = Modifier.weight(1f))
             Text(
                 modifier = Modifier.padding(horizontal = 10.dp),

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/viewmodel/NotificationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/viewmodel/NotificationViewModel.kt
@@ -6,48 +6,70 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
+import team.aliens.dms.android.data.notice.repository.NoticeRepository
 import team.aliens.dms.android.data.notification.model.NotificationTopic
 import team.aliens.dms.android.data.notification.repository.NotificationRepository
 import team.aliens.dms.android.data.point.model.PointType
 import team.aliens.dms.android.shared.date.toElapsedText
 import team.aliens.dms.android.shared.date.util.now
-import java.time.LocalDateTime
 import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
 internal class NotificationViewModel @Inject constructor(
     private val notificationRepository: NotificationRepository,
-) : BaseStateViewModel<NotificationState, NotificationSideEffect>(NotificationState()) {
+    private val noticeRepository: NoticeRepository,
+) : BaseStateViewModel<NotificationState, NotificationSideEffect>(
+    NotificationState(),
+) {
 
     init {
         fetchNotifications()
+        fetchNotices()
     }
 
     private fun fetchNotifications() {
         viewModelScope.launch(Dispatchers.IO) {
-            notificationRepository.fetchNotifications().onSuccess { notifications ->
-                val notificationsUi = notifications.map { notification -> NotificationUi(
-                    id = notification.id,
-                    title = notification.title,
-                    content = notification.content,
-                    createdAt = notification.createdAt,
-                    isRead = notification.isRead,
-                    linkId = notification.linkId,
-                    topic = notification.topic,
-                    pointDetailTopic = notification.pointDetailTopic,
-                    elapsedText = notification.createdAt.toElapsedText(now),
-                ) }
-                val notification = notificationsUi.filter { it.topic == NotificationTopic.POINT }
-                val notices = notificationsUi.filter { it.topic == NotificationTopic.NOTICE }
+            notificationRepository.fetchNotifications()
+                .onSuccess { notifications ->
+                    val notificationsUi = notifications
+                        .filter { notification -> notification.topic == NotificationTopic.POINT }
+                        .map { notification ->
+                            NotificationUi(
+                                id = notification.id,
+                                pointDetailTopic = notification.pointDetailTopic,
+                                title = notification.title,
+                                content = notification.content,
+                                isRead = notification.isRead,
+                                elapsedText = notification.createdAt.toElapsedText(now),
+                            )
+                        }
 
-                setState { it.copy(
-                    notifications = notification,
-                    notices = notices
-                ) }
-            }.onFailure {
-                sendEffect(NotificationSideEffect.FailFetchNotification)
-            }
+                    setState { it.copy(notifications = notificationsUi) }
+                }
+                .onFailure {
+                    sendEffect(NotificationSideEffect.FailFetchNotification)
+                }
+        }
+    }
+
+    private fun fetchNotices() {
+        viewModelScope.launch(Dispatchers.IO) {
+            noticeRepository.fetchNotices()
+                .onSuccess { notices ->
+                    val noticesUi = notices.map { notice ->
+                        NoticeUi(
+                            id = notice.id,
+                            title = notice.title,
+                            elapsedText = notice.createdAt.toElapsedText(now),
+                        )
+                    }
+
+                    setState { it.copy(notices = noticesUi) }
+                }
+                .onFailure {
+                    sendEffect(NotificationSideEffect.FailFetchNotice)
+                }
         }
     }
 
@@ -63,30 +85,34 @@ internal class NotificationViewModel @Inject constructor(
             )
         }
     }
-
 }
 
 @Immutable
 internal data class NotificationUi(
     val id: UUID,
-    val topic: NotificationTopic,
     val pointDetailTopic: PointType,
-    val linkId: UUID,
     val title: String,
     val content: String,
-    val createdAt: LocalDateTime,
     val isRead: Boolean,
+    val elapsedText: String,
+)
+
+@Immutable
+internal data class NoticeUi(
+    val id: UUID,
+    val title: String,
     val elapsedText: String,
 )
 
 @Immutable
 internal data class NotificationState(
     val isRecent: Boolean = false,
-    val notices: List<NotificationUi> = emptyList(),
+    val notices: List<NoticeUi> = emptyList(),
     val notifications: List<NotificationUi> = emptyList(),
 )
 
 internal sealed interface NotificationSideEffect {
-    object FailFetchNotification : NotificationSideEffect
-    object FailUpdateNotification : NotificationSideEffect
+    data object FailFetchNotification : NotificationSideEffect
+    data object FailFetchNotice : NotificationSideEffect
+    data object FailUpdateNotification : NotificationSideEffect
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/viewmodel/NotificationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/viewmodel/NotificationViewModel.kt
@@ -33,7 +33,7 @@ internal class NotificationViewModel @Inject constructor(
             notificationRepository.fetchNotifications()
                 .onSuccess { notifications ->
                     val notificationsUi = notifications
-                        .filter { notification -> notification.topic == NotificationTopic.POINT }
+                        .filter { notification -> notification.topic != NotificationTopic.NOTICE }
                         .map { notification ->
                             NotificationUi(
                                 id = notification.id,


### PR DESCRIPTION
## 개요
GET/notifications에 의존하던 공지 탭을 GET/notices 기반으로 분리해서 푸시 알림 비활성화 여부와 관계없이 공지 목록이 정상 노출되도록 수정했습니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate loading and display of notices and notifications.
  * Introduced a streamlined notice layout showing notice titles and elapsed time.
  * Notification and notice items now navigate using a single identifier.

* **Bug Fixes**
  * Improved list rendering stability by preserving item identity during updates.
  * Added distinct error handling when notices or notifications fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->