### PR TITLE
🔀 :: (#961) 새벽 자습 기능 개편

### DIFF
--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     implementation(libs.threetenbp)
 
     testImplementation(libs.androidx.junit)
+    testImplementation(libs.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
 }
 

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
     implementation(libs.threetenbp)
 
     testImplementation(libs.androidx.junit)
-    testImplementation(libs.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
 }
 

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/LateStudyScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/ui/LateStudyScreen.kt
@@ -81,13 +81,15 @@ fun LateStudyScreen(
 
     val studyTypes = viewModel.studyTypes
     val teachers = viewModel.teachers
+    val isSubmitting = viewModel.isSubmitting
 
-    val isSubmitEnabled = isSubmitEnabled(
+    val isFormValid = isSubmitEnabled(
         selectedTeacherId = selectedTeacherId,
         selectedTypeId = selectedTypeId,
         startDate = startDate,
         reason = reason,
     )
+    val isSubmitEnabled = isFormValid && !isSubmitting
 
     val filteredTeachers = remember(teacherKeyword, teachers) {
         if (teacherKeyword.isBlank()) {

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/viewmodel/LateStudyViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/viewmodel/LateStudyViewModel.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.android.feature.latestudy.viewmodel
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -11,10 +12,12 @@ import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.network.exception.ConflictException
+import team.aliens.dms.android.core.network.exception.NetworkException
 import team.aliens.dms.android.data.latestudy.model.StudyType
 import team.aliens.dms.android.data.latestudy.repository.LateStudyRepository
 import team.aliens.dms.android.network.latestudy.model.SubmitLateStudyRequest
 import team.aliens.dms.android.network.latestudy.model.TeacherResponse
+import team.aliens.dms.android.shared.exception.UnknownException
 
 @HiltViewModel
 class LateStudyViewModel @Inject constructor(
@@ -90,18 +93,38 @@ class LateStudyViewModel @Inject constructor(
                         endDate = endDate,
                     ),
                 )
-                onSuccess()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: ConflictException) {
+                Log.w(TAG, "이미 새벽 자습을 신청했습니다.", e)
                 onFailure("이미 새벽 자습을 신청했습니다.")
+                return@launch
             } catch (e: IOException) {
-                onFailure("새벽 자습 신청에 실패했습니다.")
-            } catch (e: Exception) {
-                onFailure("새벽 자습 신청에 실패했습니다.")
+                handleSubmitFailure(e, onFailure)
+                return@launch
+            } catch (e: NetworkException) {
+                handleSubmitFailure(e, onFailure)
+                return@launch
+            } catch (e: UnknownException) {
+                handleSubmitFailure(e, onFailure)
+                return@launch
             } finally {
                 isSubmitting = false
             }
+
+            onSuccess()
         }
+    }
+
+    private fun handleSubmitFailure(
+        throwable: Throwable,
+        onFailure: (String) -> Unit,
+    ) {
+        Log.e(TAG, "새벽 자습 신청에 실패했습니다.", throwable)
+        onFailure("새벽 자습 신청에 실패했습니다.")
+    }
+
+    private companion object {
+        const val TAG = "LateStudyViewModel"
     }
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/viewmodel/LateStudyViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/latestudy/viewmodel/LateStudyViewModel.kt
@@ -30,6 +30,9 @@ class LateStudyViewModel @Inject constructor(
     var teachers by mutableStateOf<List<TeacherResponse>>(emptyList())
         private set
 
+    var isSubmitting by mutableStateOf(false)
+        private set
+
     init {
         fetchStudyTypes()
         fetchTeachers()
@@ -72,7 +75,11 @@ class LateStudyViewModel @Inject constructor(
         onSuccess: () -> Unit,
         onFailure: (String) -> Unit,
     ) {
+        if (isSubmitting) return
+
         viewModelScope.launch {
+            isSubmitting = true
+
             try {
                 lateStudyRepository.submitLateStudy(
                     SubmitLateStudyRequest(
@@ -86,12 +93,14 @@ class LateStudyViewModel @Inject constructor(
                 onSuccess()
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: IOException) {
-                e.printStackTrace()
-                onFailure("새벽 자습 신청에 실패했습니다.")
             } catch (e: ConflictException) {
-                e.printStackTrace()
                 onFailure("이미 새벽 자습을 신청했습니다.")
+            } catch (e: IOException) {
+                onFailure("새벽 자습 신청에 실패했습니다.")
+            } catch (e: Exception) {
+                onFailure("새벽 자습 신청에 실패했습니다.")
+            } finally {
+                isSubmitting = false
             }
         }
     }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/latestudy/datasource/NetworkLateStudyDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/latestudy/datasource/NetworkLateStudyDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package team.aliens.dms.android.network.latestudy.datasource
 
+import team.aliens.dms.android.core.network.util.handleNetworkRequest
 import team.aliens.dms.android.network.latestudy.apiservice.LateStudyApiService
 import team.aliens.dms.android.network.latestudy.model.FetchStudyTypesResponse
 import team.aliens.dms.android.network.latestudy.model.FetchTeachersResponse
@@ -20,7 +21,8 @@ class NetworkLateStudyDataSourceImpl @Inject constructor(
     override suspend fun fetchMyStudyApplicationStatus(): StudyApplicationStatusResponse =
         lateStudyApiService.fetchMyStudyApplicationStatus()
 
-    override suspend fun submitLateStudy(request: SubmitLateStudyRequest) {
-        lateStudyApiService.submitLateStudy(request)
-    }
+    override suspend fun submitLateStudy(request: SubmitLateStudyRequest): Unit =
+        handleNetworkRequest {
+            lateStudyApiService.submitLateStudy(request)
+        }
 }


### PR DESCRIPTION
## 개요
>

- 중복 탭 시 신청 요청이 한 번만 전송
- 서버의 중복 신청(409)은 “이미 새벽 자습을 신청했습니다.”로 안내
- 기타 네트워크/서버 오류도 앱이 중단되지 않고 실패 스낵바로 복구

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate late-study submissions while a request is in progress.
  * Submission controls now remain disabled until the form is valid and the current request finishes.
  * Improved handling of network conflicts and unexpected submission failures with consistent error feedback.
  * Ensured submission state resets correctly after successful or failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->