### PR TITLE
🔀 :: (#967) 프로필 이미지 업로드 실패하는 문제 해결

### DIFF
--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/authenticator/JwtAuthenticator.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/authenticator/JwtAuthenticator.kt
@@ -8,7 +8,6 @@ import okhttp3.Route
 import team.aliens.dms.android.core.jwt.JwtProvider
 import team.aliens.dms.android.core.jwt.network.IgnoreRequests
 import team.aliens.dms.android.core.network.toHttpMethod
-import team.aliens.dms.android.core.network.util.ResourceKeys
 import javax.inject.Inject
 
 class JwtAuthenticator @Inject constructor(
@@ -75,7 +74,7 @@ class JwtAuthenticator @Inject constructor(
     }
 
     private fun Request.shouldBeIgnored(): Boolean =
-        checkS3Request(url.toString()) ||
+        url.queryParameter("X-Amz-Signature") != null ||
             ignoreRequests.requests.any { ignoreRequest ->
                 val path = url.encodedPath
                 val requestMethod = method.toHttpMethod()
@@ -96,9 +95,6 @@ class JwtAuthenticator @Inject constructor(
 
             return count
         }
-
-    private fun checkS3Request(url: String): Boolean =
-        url.contains(ResourceKeys.IMAGE_URL)
 
     private companion object {
         const val AUTHORIZATION_HEADER = "authorization"

--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/interceptor/JwtInterceptor.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/interceptor/JwtInterceptor.kt
@@ -8,7 +8,6 @@ import team.aliens.dms.android.core.jwt.JwtProvider
 import team.aliens.dms.android.core.jwt.exception.CannotUseAccessTokenException
 import team.aliens.dms.android.core.jwt.network.IgnoreRequests
 import team.aliens.dms.android.core.network.toHttpMethod
-import team.aliens.dms.android.core.network.util.ResourceKeys
 import javax.inject.Inject
 
 class JwtInterceptor @Inject constructor(
@@ -40,7 +39,7 @@ class JwtInterceptor @Inject constructor(
     )
 
     private fun Request.shouldBeIgnored(): Boolean {
-        if (checkS3Request(url.toString())) {
+        if (url.queryParameter("X-Amz-Signature") != null) {
             return true
         }
 
@@ -53,7 +52,4 @@ class JwtInterceptor @Inject constructor(
         }
     }
 
-    private fun checkS3Request(url: String): Boolean {
-        return url.contains(ResourceKeys.IMAGE_URL)
-    }
 }

--- a/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/interceptor/JwtInterceptor.kt
+++ b/core/jwt/src/main/java/team/aliens/dms/android/core/jwt/network/interceptor/JwtInterceptor.kt
@@ -51,5 +51,4 @@ class JwtInterceptor @Inject constructor(
                 requestMethod == ignoreRequest.method
         }
     }
-
 }

--- a/core/network/src/main/java/team/aliens/dms/android/core/network/util/ResourceKeys.kt
+++ b/core/network/src/main/java/team/aliens/dms/android/core/network/util/ResourceKeys.kt
@@ -1,5 +1,0 @@
-package team.aliens.dms.android.core.network.util
-
-object ResourceKeys {
-    const val IMAGE_URL = "https://image-dms.s3.ap-northeast-2.amazonaws.com/"
-}

--- a/data/src/main/kotlin/team/aliens/dms/android/data/file/mapper/FileMapper.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/file/mapper/FileMapper.kt
@@ -1,15 +1,9 @@
 package team.aliens.dms.android.data.file.mapper
 
-import team.aliens.dms.android.data.file.model.FileUrl
 import team.aliens.dms.android.data.file.model.PresignedFileUrl
-import team.aliens.dms.android.network.file.model.FetchFileUrlResponse
 import team.aliens.dms.android.network.file.model.FetchPresignedUrlResponse
 
 internal fun FetchPresignedUrlResponse.toModel(): PresignedFileUrl = PresignedFileUrl(
     fileUploadUrl = this.fileUploadUrl,
-    fileUrl = this.fileUrl,
-)
-
-internal fun FetchFileUrlResponse.toModel(): FileUrl = FileUrl(
     fileUrl = this.fileUrl,
 )

--- a/data/src/main/kotlin/team/aliens/dms/android/data/file/model/FileUrl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/file/model/FileUrl.kt
@@ -1,5 +1,0 @@
-package team.aliens.dms.android.data.file.model
-
-data class FileUrl(
-    val fileUrl: String,
-)

--- a/data/src/main/kotlin/team/aliens/dms/android/data/file/repository/FileRepository.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/file/repository/FileRepository.kt
@@ -1,12 +1,11 @@
 package team.aliens.dms.android.data.file.repository
 
 import android.os.FileUriExposedException
-import team.aliens.dms.android.data.file.model.FileUrl
 import team.aliens.dms.android.data.file.model.PresignedFileUrl
 import java.io.File
 
 abstract class FileRepository {
 
     abstract suspend fun fetchPresignedUrl(fileName: String): Result<PresignedFileUrl>
-    abstract suspend fun uploadFile(presignedUrl: String, file: File): Result<FileUrl>
+    abstract suspend fun uploadFile(presignedUrl: String, file: File): Result<Unit>
 }

--- a/data/src/main/kotlin/team/aliens/dms/android/data/file/repository/FileRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/file/repository/FileRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package team.aliens.dms.android.data.file.repository
 
 import team.aliens.dms.android.data.file.mapper.toModel
-import team.aliens.dms.android.data.file.model.FileUrl
 import team.aliens.dms.android.data.file.model.PresignedFileUrl
 import team.aliens.dms.android.network.file.datasource.NetworkFileDataSource
 import java.io.File
@@ -14,7 +13,6 @@ internal class FileRepositoryImpl @Inject constructor(
         networkFileDataSource.fetchPresignedUrl(fileName = fileName)
             .map { it.toModel() }
 
-    override suspend fun uploadFile(presignedUrl: String, file: File): Result<FileUrl> =
+    override suspend fun uploadFile(presignedUrl: String, file: File): Result<Unit> =
         networkFileDataSource.uploadFile(presignedUrl = presignedUrl, file = file)
-            .map { it.toModel() }
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/profile/viewmodel/SelectProfileViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/profile/viewmodel/SelectProfileViewModel.kt
@@ -43,14 +43,14 @@ internal class SelectProfileViewModel @Inject constructor(
                     fileRepository.uploadFile(
                         presignedUrl = presignedInfo.fileUploadUrl,
                         file = file,
-                    ).onSuccess { fileUrl ->
+                    ).onSuccess {
                         setState {
                             it.copy(
-                                profileImageUrl = fileUrl.fileUrl,
+                                profileImageUrl = presignedInfo.fileUrl,
                                 buttonEnabled = true,
                             )
                         }
-                        sendEffect(SelectProfileSideEffect.SuccessProfileImage(fileUrl.fileUrl))
+                        sendEffect(SelectProfileSideEffect.SuccessProfileImage(presignedInfo.fileUrl))
                     }.onFailure {
                         sendEffect(SelectProfileSideEffect.FailProfileImage)
                     }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/file/apiservice/FileApiService.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/file/apiservice/FileApiService.kt
@@ -6,7 +6,6 @@ import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Query
 import retrofit2.http.Url
-import team.aliens.dms.android.network.file.model.FetchFileUrlResponse
 import team.aliens.dms.android.network.file.model.FetchPresignedUrlResponse
 
 internal interface FileApiService {
@@ -20,5 +19,5 @@ internal interface FileApiService {
     suspend fun uploadFile(
         @Url presignedUrl: String,
         @Body file: RequestBody,
-    ): FetchFileUrlResponse
+    )
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSource.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSource.kt
@@ -1,10 +1,9 @@
 package team.aliens.dms.android.network.file.datasource
 
-import team.aliens.dms.android.network.file.model.FetchFileUrlResponse
 import team.aliens.dms.android.network.file.model.FetchPresignedUrlResponse
 import java.io.File
 
 abstract class NetworkFileDataSource {
     abstract suspend fun fetchPresignedUrl(fileName: String): Result<FetchPresignedUrlResponse>
-    abstract suspend fun uploadFile(presignedUrl: String, file: File): Result<FetchFileUrlResponse>
+    abstract suspend fun uploadFile(presignedUrl: String, file: File): Result<Unit>
 }

--- a/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/file/datasource/NetworkFileDataSourceImpl.kt
@@ -6,7 +6,6 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import team.aliens.dms.android.core.network.util.RequestType
 import team.aliens.dms.android.network.file.apiservice.FileApiService
-import team.aliens.dms.android.network.file.model.FetchFileUrlResponse
 import team.aliens.dms.android.network.file.model.FetchPresignedUrlResponse
 import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
 import java.io.File
@@ -20,7 +19,7 @@ internal class NetworkFileDataSourceImpl @Inject constructor(
         runCatchingCancellable { fileApiService.fetchPresignedUrl(fileName) }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override suspend fun uploadFile(presignedUrl: String, file: File): Result<FetchFileUrlResponse> =
+    override suspend fun uploadFile(presignedUrl: String, file: File): Result<Unit> =
         runCatchingCancellable {
             fileApiService.uploadFile(
                 presignedUrl = presignedUrl,

--- a/network/src/main/kotlin/team/aliens/dms/android/network/file/model/FetchFileUrlResponse.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/file/model/FetchFileUrlResponse.kt
@@ -1,7 +1,0 @@
-package team.aliens.dms.android.network.file.model
-
-import com.google.gson.annotations.SerializedName
-
-data class FetchFileUrlResponse(
-    @SerializedName("file_url") val fileUrl: String,
-)


### PR DESCRIPTION
## 개요
> 프로필 이미지 업로드가 안 되는 문제를 해결하였습니다.

## 작업사항
- Presigned S3 URL은 X-Amz-Signature로 판별해 JWT 헤더를 붙이지 않도록 수정
- S3 PUT의 빈 응답을 Unit으로 처리해 응답 JSON 파싱 실패 제거
- 업로드 완료 후 URL은 PUT 응답이 아닌 presigned URL 발급 응답의 fileUrl을 사용하도록 변경


## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of secure file-storage requests by reliably recognizing signed URLs.
  * Fixed profile image upload success handling to use the correct uploaded image URL.

* **Refactor**
  * Simplified file uploads to report success or failure without returning redundant response data.
  * Removed obsolete file URL models and mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->