### PR TITLE
🔀 :: (#968) 알림함 디자인 수정

### DIFF
--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/NotificationScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/notification/ui/NotificationScreen.kt
@@ -142,7 +142,9 @@ private fun NotificationScreen(
             }
         }
         HorizontalPager(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { page ->
@@ -167,7 +169,7 @@ internal fun NotificationItems(
     onNotificationClick: (PointType, UUID) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
         items(
             items = notifications,
             key = { item -> item.id },


### PR DESCRIPTION
## 개요
> 알림 탭 목록이 적을 때 상단 빈 공간이 생기지 않도록 Pager와 목록 높이를 화면 잔여 영역으로 고정했습니다.

## 작업사항

## 추가 로 할 말
