### PR TITLE
🔀 :: (#969) 경과 시간의 0달 전 표시 오류 수정

### DIFF
--- a/shared/date/src/main/java/team/aliens/dms/android/shared/date/Extensions.kt
+++ b/shared/date/src/main/java/team/aliens/dms/android/shared/date/Extensions.kt
@@ -42,6 +42,7 @@ fun LocalDateTime.toElapsedText(now: LocalDateTime): String {
         minutes < 60 -> "${minutes}분 전"
         hours < 24 -> "${hours}시간 전"
         days < 30 -> "${days}일 전"
+        months < 1 -> "${days}일 전"
         months < 12 -> "${months}달 전"
         else -> "${years}년 전"
     }


### PR DESCRIPTION
## 개요
> 0일 이상이지만 한 달이 지나지 않은 알림은 ~일 전으로 표시해 0달 전 오류를 수정했습니다.

## 작업사항


## 추가 로 할 말
