### PR TITLE
🔀 :: (#975) 알림 Enum 파싱 예외로 인한 앱 종료 문제 해결

### DIFF
--- a/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/Notification.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/Notification.kt
@@ -18,15 +18,20 @@ data class Notification(
 )
 
 fun FetchNotificationsResponse.toModel(): List<Notification> =
-    this.notifications.map(FetchNotificationsResponse.NotificationResponse::toModel)
+    this.notifications.mapNotNull(FetchNotificationsResponse.NotificationResponse::toModel)
 
-private fun FetchNotificationsResponse.NotificationResponse.toModel(): Notification = Notification(
-    id = this.id,
-    topic = NotificationTopic.valueOf(this.topic),
-    pointDetailTopic = PointType.valueOf(this.pointDetailTopic ?: "ALL"),
-    linkId = this.linkId,
-    title = this.title,
-    content = this.content,
-    createdAt = this.createdAt.toLocalDateTime(),
-    isRead = this.isRead,
-)
+private fun FetchNotificationsResponse.NotificationResponse.toModel(): Notification? {
+    val topic = NotificationTopic.entries.find { it.name == this.topic } ?: return null
+    val pointDetailTopic = PointType.entries.find { it.name == (this.pointDetailTopic ?: "ALL") } ?: return null
+
+    return Notification(
+        id = this.id,
+        topic = topic,
+        pointDetailTopic = pointDetailTopic,
+        linkId = this.linkId,
+        title = this.title,
+        content = this.content,
+        createdAt = this.createdAt.toLocalDateTime(),
+        isRead = this.isRead,
+    )
+}

--- a/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/NotificationTopicGroup.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/notification/model/NotificationTopicGroup.kt
@@ -23,20 +23,26 @@ fun FetchNotificationTopicStatusResponse.toModel(): List<NotificationTopicGroup.
 
 @JvmName("ListTopicGroupResponse")
 private fun List<FetchNotificationTopicStatusResponse.TopicGroupResponse>.toModel(): List<NotificationTopicGroup.Status> =
-    this.map(FetchNotificationTopicStatusResponse.TopicGroupResponse::toModel)
+    this.mapNotNull(FetchNotificationTopicStatusResponse.TopicGroupResponse::toModel)
 
-private fun FetchNotificationTopicStatusResponse.TopicGroupResponse.toModel(): NotificationTopicGroup.Status =
-    NotificationTopicGroup.Status(
-        topicGroup = NotificationTopicGroup.valueOf(this.topicGroup),
+private fun FetchNotificationTopicStatusResponse.TopicGroupResponse.toModel(): NotificationTopicGroup.Status? {
+    val topicGroup = NotificationTopicGroup.entries.find { it.name == this.topicGroup } ?: return null
+
+    return NotificationTopicGroup.Status(
+        topicGroup = topicGroup,
         groupName = this.groupName,
         topicSubscriptions = this.topicSubscriptions.toModel(),
     )
+}
 
 private fun List<FetchNotificationTopicStatusResponse.TopicGroupResponse.TopicSubscriptionResponse>.toModel(): List<NotificationTopicGroup.Status.TopicSubscription> =
-    this.map(FetchNotificationTopicStatusResponse.TopicGroupResponse.TopicSubscriptionResponse::toModel)
+    this.mapNotNull(FetchNotificationTopicStatusResponse.TopicGroupResponse.TopicSubscriptionResponse::toModel)
 
-private fun FetchNotificationTopicStatusResponse.TopicGroupResponse.TopicSubscriptionResponse.toModel(): NotificationTopicGroup.Status.TopicSubscription =
-    NotificationTopicGroup.Status.TopicSubscription(
-        topic = NotificationTopic.valueOf(this.topic),
+private fun FetchNotificationTopicStatusResponse.TopicGroupResponse.TopicSubscriptionResponse.toModel(): NotificationTopicGroup.Status.TopicSubscription? {
+    val topic = NotificationTopic.entries.find { it.name == this.topic } ?: return null
+
+    return NotificationTopicGroup.Status.TopicSubscription(
+        topic = topic,
         subscribed = this.subscribed,
     )
+}

--- a/data/src/main/kotlin/team/aliens/dms/android/data/notification/repository/NotificationRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/notification/repository/NotificationRepositoryImpl.kt
@@ -64,10 +64,10 @@ internal class NotificationRepositoryImpl @Inject constructor(
         deviceToken: String,
     ): Result<List<NotificationTopicGroup.Status>> =
         networkNotificationDataSource.fetchNotificationTopicStatus(deviceToken = deviceToken)
-            .map { it.toModel() }
+            .mapCatching { it.toModel() }
 
     override suspend fun fetchNotifications(): Result<List<Notification>> =
-        networkNotificationDataSource.fetchNotifications().map { it.toModel() }
+        networkNotificationDataSource.fetchNotifications().mapCatching { it.toModel() }
 
     override suspend fun saveDeviceToken(deviceToken: String): Result<Unit> =
         deviceDataStoreDataSource.storeDeviceToken(deviceToken)

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/setting/ui/SettingScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/setting/ui/SettingScreen.kt
@@ -65,6 +65,8 @@ internal fun Setting(
             when (it) {
                 is SettingSideEffect.CannotFetchNotificationStatus ->
                     updatedOnShowSnackBar(DmsSnackBarType.ERROR, "알림 상태 조회를 실패했어요")
+                is SettingSideEffect.CannotUpdateNotificationStatus ->
+                    updatedOnShowSnackBar(DmsSnackBarType.ERROR, "알림 상태 변경을 실패했어요")
                 is SettingSideEffect.SignOutSuccess -> updatedOnNavigateSignIn()
                 is SettingSideEffect.WithdrawSuccess -> updatedOnNavigateSignIn()
                 is SettingSideEffect.WithdrawFailed ->

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/setting/viewmodel/SettingViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/setting/viewmodel/SettingViewModel.kt
@@ -9,9 +9,10 @@ import team.aliens.dms.android.core.theme.ThemeMode
 import team.aliens.dms.android.core.theme.datastore.ThemeDataStoreDataSource
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.data.auth.repository.AuthRepository
+import team.aliens.dms.android.data.notification.model.NotificationTopic
 import team.aliens.dms.android.data.notification.model.NotificationTopicGroup
-import team.aliens.dms.android.data.student.repository.StudentRepository
 import team.aliens.dms.android.data.notification.repository.NotificationRepository
+import team.aliens.dms.android.data.student.repository.StudentRepository
 import javax.inject.Inject
 
 @HiltViewModel
@@ -89,14 +90,40 @@ class SettingViewModel @Inject constructor(
     }
 
     internal fun updateNotificationStatus(isOnNotification: Boolean) {
-        setState { settingState ->
-            settingState.copy(isOnNotification = !isOnNotification)
+        val subscriptions = uiState.value.notificationTopicStatus.flatMap { status ->
+            status.topicSubscriptions.map { subscription ->
+                NotificationTopic.Subscription(
+                    topic = subscription.topic,
+                    subscribe = !isOnNotification,
+                )
+            }
         }
-        if (isOnNotification) /* 구독 취소 */ setNotificationStatus() else return // TODO 구독 업데이트 (false -> true)
-    }
 
-    private fun setNotificationStatus() {
-        // TODO: implement notification subscription update
+        if (subscriptions.isEmpty()) {
+            sendEffect(SettingSideEffect.CannotUpdateNotificationStatus)
+            return
+        }
+
+        viewModelScope.launch {
+            notificationRepository.batchUpdateNotificationTopic(subscriptions)
+                .onSuccess {
+                    setState { settingState ->
+                        settingState.copy(
+                            isOnNotification = !isOnNotification,
+                            notificationTopicStatus = settingState.notificationTopicStatus.map { status ->
+                                status.copy(
+                                    topicSubscriptions = status.topicSubscriptions.map { subscription ->
+                                        subscription.copy(subscribed = !isOnNotification)
+                                    },
+                                )
+                            },
+                        )
+                    }
+                }
+                .onFailure {
+                    sendEffect(SettingSideEffect.CannotUpdateNotificationStatus)
+                }
+        }
     }
 }
 
@@ -109,6 +136,7 @@ data class SettingState(
 
 sealed class SettingSideEffect {
     object CannotFetchNotificationStatus : SettingSideEffect()
+    object CannotUpdateNotificationStatus : SettingSideEffect()
     object SignOutSuccess : SettingSideEffect()
     object WithdrawSuccess : SettingSideEffect()
     object WithdrawFailed : SettingSideEffect()


### PR DESCRIPTION
## 개요
>  알림 상태 Enum 파싱 시 예외 처리 누락되는 문제가 있었습니다.

## 작업사항
-  파싱 예외 처리 및 기본값 적용으로 해결했습니다.

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications with unrecognized topics are now skipped instead of causing failures.
  * Notification topic status updates now handle mapping and network errors safely.
  * Notification settings remain synchronized across all topics after updates.
  * Failed notification status changes now display an error message in the settings screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->