### PR TITLE
🔀 :: (#977) 귀가 상태 미리보기 갱신 오류 수정

### DIFF
--- a/data/src/main/kotlin/team/aliens/dms/android/data/remain/repository/RemainsRepository.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/remain/repository/RemainsRepository.kt
@@ -9,7 +9,7 @@ abstract class RemainsRepository {
 
     abstract suspend fun updateRemainsOption(optionId: UUID): Result<Unit>
 
-    abstract suspend fun fetchAppliedRemainsOption(): Result<AppliedRemainsOption>
+    abstract suspend fun fetchAppliedRemainsOption(): Result<AppliedRemainsOption?>
 
     abstract suspend fun fetchRemainsApplicationTime(): Result<RemainsApplicationTime>
 

--- a/data/src/main/kotlin/team/aliens/dms/android/data/remain/repository/RemainsRepositoryImpl.kt
+++ b/data/src/main/kotlin/team/aliens/dms/android/data/remain/repository/RemainsRepositoryImpl.kt
@@ -15,9 +15,9 @@ internal class RemainsRepositoryImpl @Inject constructor(
     override suspend fun updateRemainsOption(optionId: UUID): Result<Unit> =
         networkRemainsDataSource.updateRemainsOption(optionId)
 
-    override suspend fun fetchAppliedRemainsOption(): Result<AppliedRemainsOption> =
+    override suspend fun fetchAppliedRemainsOption(): Result<AppliedRemainsOption?> =
         networkRemainsDataSource.fetchAppliedRemainsOption()
-            .map { it.toModel() }
+            .map { it?.toModel() }
 
     override suspend fun fetchRemainsApplicationTime(): Result<RemainsApplicationTime> =
         networkRemainsDataSource.fetchRemainsApplicationTime()

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
@@ -31,6 +31,7 @@ internal class ApplicationViewModel @Inject constructor(
 
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences("application_prefs", Context.MODE_PRIVATE)
+    private var remainApplicationTitleVersion = 0
 
     init {
         getAllVotes()
@@ -53,9 +54,13 @@ internal class ApplicationViewModel @Inject constructor(
     }
 
     private fun fetchAppliedRemainsOption() {
-        viewModelScope.launch(Dispatchers.IO) {
+        val titleVersion = remainApplicationTitleVersion
+
+        viewModelScope.launch {
             remainsRepository.fetchAppliedRemainsOption()
                 .onSuccess { appliedOption ->
+                    if (titleVersion != remainApplicationTitleVersion) return@onSuccess
+
                     setState { it.copy(remainApplicationTitle = appliedOption?.title) }
                 }
         }
@@ -105,6 +110,8 @@ internal class ApplicationViewModel @Inject constructor(
     }
 
     internal fun setRemainApplication(title: String) {
+        remainApplicationTitleVersion += 1
+
         setState {
             it.copy(remainApplicationTitle = title)
         }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/main/application/viewmodel/ApplicationViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import team.aliens.dms.android.core.ui.viewmodel.BaseStateViewModel
 import team.aliens.dms.android.data.latestudy.repository.LateStudyRepository
+import team.aliens.dms.android.data.remain.repository.RemainsRepository
 import team.aliens.dms.android.data.voting.model.AllVoteSearch
 import team.aliens.dms.android.data.voting.repository.VotingRepository
 import team.aliens.dms.android.network.latestudy.model.StudyApplicationStatusResponse
@@ -24,6 +25,7 @@ import javax.inject.Inject
 internal class ApplicationViewModel @Inject constructor(
     private val votingRepository: VotingRepository,
     private val lateStudyRepository: LateStudyRepository,
+    private val remainsRepository: RemainsRepository,
     @ApplicationContext private val context: Context,
 ) : BaseStateViewModel<ApplicationState, Unit>(ApplicationState()) {
 
@@ -32,7 +34,7 @@ internal class ApplicationViewModel @Inject constructor(
 
     init {
         getAllVotes()
-        loadAppliedRemainsTitle()
+        fetchAppliedRemainsOption()
         loadAppliedLateStudy()
         fetchMyStudyApplicationStatus()
     }
@@ -50,13 +52,12 @@ internal class ApplicationViewModel @Inject constructor(
         }
     }
 
-    private fun loadAppliedRemainsTitle() {
-        val savedTitle = sharedPreferences.getString(KEY_APPLIED_REMAINS_TITLE, null)
-
-        if (savedTitle != null) {
-            setState {
-                it.copy(remainApplicationTitle = savedTitle)
-            }
+    private fun fetchAppliedRemainsOption() {
+        viewModelScope.launch(Dispatchers.IO) {
+            remainsRepository.fetchAppliedRemainsOption()
+                .onSuccess { appliedOption ->
+                    setState { it.copy(remainApplicationTitle = appliedOption?.title) }
+                }
         }
     }
 
@@ -104,10 +105,6 @@ internal class ApplicationViewModel @Inject constructor(
     }
 
     internal fun setRemainApplication(title: String) {
-        sharedPreferences.edit()
-            .putString(KEY_APPLIED_REMAINS_TITLE, title)
-            .apply()
-
         setState {
             it.copy(remainApplicationTitle = title)
         }
@@ -127,7 +124,6 @@ internal class ApplicationViewModel @Inject constructor(
     }
 
     companion object {
-        private const val KEY_APPLIED_REMAINS_TITLE = "applied_remains_title"
         private const val KEY_APPLIED_LATE_STUDY_TITLE = "applied_late_study_title"
     }
 }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/remain/ui/RemainApplicationScreen.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/remain/ui/RemainApplicationScreen.kt
@@ -129,7 +129,7 @@ private fun RemainApplicationScreen(
             text = "변경하기",
             buttonType = ButtonType.Contained,
             buttonColor = ButtonColor.Primary,
-            enabled = state.selectRemainsOptionId != null,
+            enabled = state.selectRemainsOptionId != null && !state.isChangingRemainsOption,
             onClick = changeRemainsOption,
         )
     }

--- a/feature/src/main/kotlin/team/aliens/dms/android/feature/remain/viewmodel/RemainApplicationViewModel.kt
+++ b/feature/src/main/kotlin/team/aliens/dms/android/feature/remain/viewmodel/RemainApplicationViewModel.kt
@@ -28,7 +28,7 @@ class RemainApplicationViewModel @Inject constructor(
         viewModelScope.launch {
             remainsRepository.fetchRemainsOptions().onSuccess { remainsOptions ->
                 val selectRemainsOptionId =
-                    remainsOptions.find { it.applied }?.id ?: UUID.randomUUID()
+                    remainsOptions.find { it.applied }?.id
                 setState {
                     it.copy(
                         remainsOptions = remainsOptions,
@@ -48,6 +48,8 @@ class RemainApplicationViewModel @Inject constructor(
     }
 
     internal fun setSelectRemainsOption(remainsOptionId: UUID?) {
+        if (uiState.value.isChangingRemainsOption) return
+
         setState { it.copy(selectRemainsOptionId = remainsOptionId) }
     }
 
@@ -55,29 +57,35 @@ class RemainApplicationViewModel @Inject constructor(
         onShowSnackBar: (DmsSnackBarType, String) -> Unit,
     ) {
         viewModelScope.launch {
+            if (uiState.value.isChangingRemainsOption) return@launch
+
             if (!isWithinApplicationTime()) {
                 onShowSnackBar(DmsSnackBarType.ERROR, "잔류 신청 시간이 아닙니다")
                 return@launch
             }
-            uiState.value.selectRemainsOptionId?.let { optionId ->
-                remainsRepository.updateRemainsOption(optionId = optionId)
-                    .onSuccess {
-                        val remainsOptions = uiState.value.remainsOptions.map { remainsOption ->
-                            remainsOption.copy(applied = remainsOption.id == uiState.value.selectRemainsOptionId)
-                        }
-                        val appliedOption = remainsOptions.find { it.applied }
-                        setState {
-                            it.copy(
-                                remainsOptions = remainsOptions,
-                                selectedRemainTitle = appliedOption?.title
-                            )
-                        }
-                        onShowSnackBar(DmsSnackBarType.SUCCESS, "잔류 신청이 완료되었습니다")
-                    }.onFailure {
-                        onShowSnackBar(DmsSnackBarType.ERROR, "잔류 신청에 실패했습니다")
+            val optionId = uiState.value.selectRemainsOptionId ?: return@launch
+            setState { it.copy(isChangingRemainsOption = true) }
+
+            remainsRepository.updateRemainsOption(optionId = optionId)
+                .onSuccess {
+                    val remainsOptions = uiState.value.remainsOptions.map { remainsOption ->
+                        remainsOption.copy(applied = remainsOption.id == optionId)
                     }
+                    val appliedOption = remainsOptions.find { it.applied }
+                    setState {
+                        it.copy(
+                            remainsOptions = remainsOptions,
+                            selectRemainsOptionId = optionId,
+                            selectedRemainTitle = appliedOption?.title,
+                            isChangingRemainsOption = false,
+                        )
+                    }
+                    onShowSnackBar(DmsSnackBarType.SUCCESS, "잔류 신청이 완료되었습니다")
+                }.onFailure {
+                    setState { it.copy(isChangingRemainsOption = false) }
+                    onShowSnackBar(DmsSnackBarType.ERROR, "잔류 신청에 실패했습니다")
                 }
-            }
+        }
     }
 
     private fun isWithinApplicationTime(): Boolean {
@@ -115,5 +123,6 @@ data class RemainApplicationState(
     val remainsOptions: List<RemainsOption> = emptyList(),
     val selectRemainsOptionId: UUID? = null,
     val selectedRemainTitle: String? = null,
+    val isChangingRemainsOption: Boolean = false,
     val remainsApplicationTime: RemainsApplicationTime = RemainsApplicationTime(),
 )

--- a/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSource.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSource.kt
@@ -9,7 +9,7 @@ abstract class NetworkRemainsDataSource {
 
     abstract suspend fun updateRemainsOption(optionId: UUID): Result<Unit>
 
-    abstract suspend fun fetchAppliedRemainsOption(): Result<FetchAppliedRemainsOptionResponse>
+    abstract suspend fun fetchAppliedRemainsOption(): Result<FetchAppliedRemainsOptionResponse?>
 
     abstract suspend fun fetchRemainsApplicationTime(): Result<FetchRemainsApplicationTimeResponse>
 

--- a/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSourceImpl.kt
+++ b/network/src/main/kotlin/team/aliens/dms/android/network/remains/datasource/NetworkRemainsDataSourceImpl.kt
@@ -4,6 +4,7 @@ import team.aliens.dms.android.network.remains.model.FetchAppliedRemainsOptionRe
 import team.aliens.dms.android.network.remains.model.FetchRemainsApplicationTimeResponse
 import team.aliens.dms.android.network.remains.model.FetchRemainsOptionsResponse
 import team.aliens.dms.android.shared.exception.util.runCatchingCancellable
+import retrofit2.HttpException
 import java.util.UUID
 import javax.inject.Inject
 
@@ -13,8 +14,14 @@ internal class NetworkRemainsDataSourceImpl @Inject constructor(
     override suspend fun updateRemainsOption(optionId: UUID): Result<Unit> =
         runCatchingCancellable { remainsApiService.updateRemainsOption(optionId) }
 
-    override suspend fun fetchAppliedRemainsOption(): Result<FetchAppliedRemainsOptionResponse> =
-        runCatchingCancellable { remainsApiService.fetchAppliedRemainsOption() }
+    override suspend fun fetchAppliedRemainsOption(): Result<FetchAppliedRemainsOptionResponse?> =
+        runCatchingCancellable {
+            try {
+                remainsApiService.fetchAppliedRemainsOption()
+            } catch (exception: HttpException) {
+                if (exception.code() == 404) null else throw exception
+            }
+        }
 
     override suspend fun fetchRemainsApplicationTime(): Result<FetchRemainsApplicationTimeResponse> =
         runCatchingCancellable { remainsApiService.fetchRemainsApplicationTime() }


### PR DESCRIPTION
## 개요
> 귀가 상태 미리보기 갱신이 안 되는 문제를 해결합니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Applied remains options are now loaded from the server, ensuring the displayed selection reflects current data.
  - The app now supports accounts without an applied remains option.

- **Bug Fixes**
  - Missing applied-option responses no longer cause an error.
  - Prevented duplicate remains-option updates by disabling the change button while an update is in progress.
  - Selection state now stays synchronized after successful updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->